### PR TITLE
Add Home page render assertion in App test

### DIFF
--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,10 +1,12 @@
-import { render } from '@testing-library/react'
-import { describe, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
 
 import App from '../src/App'
 
 describe('App Component', () => {
   test('renders correctly', () => {
     render(<App />)
+
+    expect(screen.getByText('home.hero_title')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- Ensure App test validates Home page render by checking for `home.hero_title`

## Testing
- `npm test` *(fails: Coverage for lines (48.61%) does not meet global threshold (85%))*

------
https://chatgpt.com/codex/tasks/task_e_689f7f58376c832eb86fde04aee2460f