### PR TITLE
feat: add logged-in home view

### DIFF
--- a/mocks/handlers/auth/login.handler.ts
+++ b/mocks/handlers/auth/login.handler.ts
@@ -7,6 +7,7 @@ import { DEFAULT_EMAIL, DEFAULT_PASS } from '../../constants/constants'
 
 import errorResponse from './fixtures/login.error.json'
 import successResponse from './fixtures/login.success.json'
+import { setLoggedInState } from './me.handler'
 
 export const loginHandler = http.post(
   RELATIVE_API_ROUTES.AUTH.LOGIN,
@@ -24,6 +25,7 @@ export const loginHandler = http.post(
       })
     }
 
+    setLoggedInState(true)
     return HttpResponse.json(successResponse, {
       status: 200,
       headers: {

--- a/mocks/handlers/auth/logout.handler.ts
+++ b/mocks/handlers/auth/logout.handler.ts
@@ -3,8 +3,10 @@ import { http, HttpResponse } from 'msw'
 import { RELATIVE_API_ROUTES } from '@/api/routes'
 
 import successResponse from './fixtures/logout.success.json'
+import { setLoggedInState } from './me.handler'
 
 export const logoutHandler = http.post(RELATIVE_API_ROUTES.AUTH.LOGOUT, () => {
+  setLoggedInState(false)
   return HttpResponse.json(successResponse, {
     status: 200,
     headers: {

--- a/mocks/handlers/auth/me.handler.ts
+++ b/mocks/handlers/auth/me.handler.ts
@@ -9,6 +9,11 @@ type Override = 'auto' | 'logged-in' | 'logged-out'
 // Build-time override via .env (optional). Example: VITE_MSW_FORCE_AUTH=logged-in
 let AUTH_OVERRIDE: Override =
   (import.meta.env.PUBLIC_MSW_FORCE_AUTH as Override) ?? 'auto'
+let IS_LOGGED_IN = false
+
+export const setLoggedInState = (next: boolean) => {
+  IS_LOGGED_IN = next
+}
 
 function getCookie(name: string, cookieHeader: string | null): string | null {
   if (!cookieHeader) return null
@@ -52,7 +57,12 @@ export const meHandler = http.get(
       })
     }
 
-    // 2) Cookie-based default
+    // 2) Session-based flag
+    if (IS_LOGGED_IN) {
+      return HttpResponse.json(successUser, { status: 200 })
+    }
+
+    // 3) Cookie-based default
     const cookieHeader = request.headers.get('cookie')
     const token = getCookie('authToken', cookieHeader)
     if (token) {

--- a/src/api/auth/me.service.ts
+++ b/src/api/auth/me.service.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '@/api/axios'
+import { RELATIVE_API_ROUTES } from '@/api/routes'
+
+export const fetchMe = async () => {
+  const response = await apiClient.get(RELATIVE_API_ROUTES.AUTH.ME)
+  return response.data
+}

--- a/src/assets/i18n/locales/en/common.json
+++ b/src/assets/i18n/locales/en/common.json
@@ -57,7 +57,13 @@
     "my_books": "My books",
     "community_title": "Join the community",
     "community_subtitle": "Create your book house and start sharing books today",
-    "explore_community": "Explore community"
+    "explore_community": "Explore community",
+    "hero_logged_in_title": "Welcome back",
+    "hero_logged_in_subtitle": "Discover new books from the community.",
+    "hero_logged_in_cta": "Browse books",
+    "community_logged_in_title": "Your community",
+    "community_logged_in_subtitle": "See what's happening with other readers.",
+    "community_logged_in_cta": "Go to community"
   },
   "activity": {
     "added": "Ofreciste",

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -57,7 +57,13 @@
     "my_books": "Mis libros",
     "community_title": "Únete a la comunidad",
     "community_subtitle": "Crea tu casita y empieza a intercambiar libros hoy mismo",
-    "explore_community": "Explorar comunidad"
+    "explore_community": "Explorar comunidad",
+    "hero_logged_in_title": "Bienvenido de nuevo",
+    "hero_logged_in_subtitle": "Descubre nuevos libros de la comunidad.",
+    "hero_logged_in_cta": "Explorar libros",
+    "community_logged_in_title": "Tu comunidad",
+    "community_logged_in_subtitle": "Mira qué sucede con otros lectores.",
+    "community_logged_in_cta": "Ir a la comunidad"
   },
   "activity": {
     "added": "You added",

--- a/src/components/home/CommunitySectionLoggedIn.tsx
+++ b/src/components/home/CommunitySectionLoggedIn.tsx
@@ -21,4 +21,3 @@ export const CommunitySectionLoggedIn = () => {
     </section>
   )
 }
-

--- a/src/components/home/CommunitySectionLoggedIn.tsx
+++ b/src/components/home/CommunitySectionLoggedIn.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+import { HOME_URLS } from '@/constants/constants'
+import styles from '@/pages/home/HomePage.module.scss'
+
+export const CommunitySectionLoggedIn = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  return (
+    <section className={styles.communitySection}>
+      <h2>{t('home.community_logged_in_title')}</h2>
+      <p>{t('home.community_logged_in_subtitle')}</p>
+      <button
+        className={styles.ctaButton}
+        onClick={() => navigate(`/${HOME_URLS.COMMUNITY}`)}
+      >
+        {t('home.community_logged_in_cta')}
+      </button>
+    </section>
+  )
+}
+

--- a/src/components/home/HeroLoggedIn.tsx
+++ b/src/components/home/HeroLoggedIn.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+import { HOME_URLS } from '@/constants/constants'
+import styles from '@/pages/home/HomePage.module.scss'
+
+export const HeroLoggedIn = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  return (
+    <section className={styles.hero}>
+      <h1>{t('home.hero_logged_in_title')}</h1>
+      <p>{t('home.hero_logged_in_subtitle')}</p>
+      <button
+        className={styles.ctaButton}
+        onClick={() => navigate(`/${HOME_URLS.BOOKS}`)}
+      >
+        {t('home.hero_logged_in_cta')}
+      </button>
+    </section>
+  )
+}
+

--- a/src/components/home/HeroLoggedIn.tsx
+++ b/src/components/home/HeroLoggedIn.tsx
@@ -21,4 +21,3 @@ export const HeroLoggedIn = () => {
     </section>
   )
 }
-

--- a/src/hooks/api/useIsLoggedIn.ts
+++ b/src/hooks/api/useIsLoggedIn.ts
@@ -1,11 +1,5 @@
-import { apiClient } from '@api/axios'
-import { RELATIVE_API_ROUTES } from '@api/routes'
+import { fetchMe } from '@api/auth/me.service'
 import { useQuery } from '@tanstack/react-query'
-
-const fetchMe = async () => {
-  const res = await apiClient.get(RELATIVE_API_ROUTES.AUTH.ME)
-  return res.data
-}
 
 export const useIsLoggedIn = () => {
   const { data, isError, isLoading } = useQuery({

--- a/src/hooks/api/useIsLoggedIn.ts
+++ b/src/hooks/api/useIsLoggedIn.ts
@@ -1,12 +1,10 @@
+import { apiClient } from '@api/axios'
 import { RELATIVE_API_ROUTES } from '@api/routes'
 import { useQuery } from '@tanstack/react-query'
 
 const fetchMe = async () => {
-  const res = await fetch(RELATIVE_API_ROUTES.AUTH.ME, {
-    credentials: 'include',
-  })
-  if (!res.ok) throw new Error('Not authenticated')
-  return res.json()
+  const res = await apiClient.get(RELATIVE_API_ROUTES.AUTH.ME)
+  return res.data
 }
 
 export const useIsLoggedIn = () => {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,7 +1,13 @@
 import { BookCard } from '@components/book/BookCard'
+import { CommunitySectionLoggedIn } from '@components/home/CommunitySectionLoggedIn'
+import { HeroLoggedIn } from '@components/home/HeroLoggedIn'
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
 import { UserActivityItem } from '@components/user/UserActivityItem'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+import { HOME_URLS } from '@/constants/constants'
+import { useIsLoggedIn } from '@/hooks/api/useIsLoggedIn'
 
 import styles from './HomePage.module.scss'
 
@@ -42,16 +48,29 @@ const mockActivities = [
 
 export const HomePage = () => {
   const { t } = useTranslation()
+  const { isLoggedIn, isLoading } = useIsLoggedIn()
+  const navigate = useNavigate()
+
+  if (isLoading) return null
 
   return (
     <BaseLayout>
       <div className={styles.homeWrapper}>
         {/* HERO */}
-        <section className={styles.hero}>
-          <h1>{t('home.hero_title')}</h1>
-          <p>{t('home.hero_subtitle')}</p>
-          <button className={styles.ctaButton}>{t('home.hero_cta')}</button>
-        </section>
+        {isLoggedIn ? (
+          <HeroLoggedIn />
+        ) : (
+          <section className={styles.hero}>
+            <h1>{t('home.hero_title')}</h1>
+            <p>{t('home.hero_subtitle')}</p>
+            <button
+              className={styles.ctaButton}
+              onClick={() => navigate(`/${HOME_URLS.LOGIN}`)}
+            >
+              {t('home.hero_cta')}
+            </button>
+          </section>
+        )}
 
         {/* STATS */}
         <section className={styles.stats}>
@@ -89,13 +108,20 @@ export const HomePage = () => {
         </section>
 
         {/* CTA COMUNIDAD */}
-        <section className={styles.communitySection}>
-          <h2>{t('home.community_title')}</h2>
-          <p>{t('home.community_subtitle')}</p>
-          <button className={styles.ctaButton}>
-            {t('home.explore_community')}
-          </button>
-        </section>
+        {isLoggedIn ? (
+          <CommunitySectionLoggedIn />
+        ) : (
+          <section className={styles.communitySection}>
+            <h2>{t('home.community_title')}</h2>
+            <p>{t('home.community_subtitle')}</p>
+            <button
+              className={styles.ctaButton}
+              onClick={() => navigate(`/${HOME_URLS.LOGIN}`)}
+            >
+              {t('home.explore_community')}
+            </button>
+          </section>
+        )}
       </div>
     </BaseLayout>
   )

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,12 +1,33 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import App from '../src/App'
+import { useIsLoggedIn } from '../src/hooks/api/useIsLoggedIn'
+
+vi.mock('../src/hooks/api/useIsLoggedIn')
 
 describe('App Component', () => {
-  test('renders correctly', () => {
+  test('renders correctly for guest users', () => {
+    vi.mocked(useIsLoggedIn).mockReturnValue({
+      isLoggedIn: false,
+      isLoading: false,
+      isError: false,
+    })
+
     render(<App />)
 
     expect(screen.getByText('home.hero_title')).toBeVisible()
+  })
+
+  test('renders correctly for logged in users', () => {
+    vi.mocked(useIsLoggedIn).mockReturnValue({
+      isLoggedIn: true,
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<App />)
+
+    expect(screen.getByText('home.hero_logged_in_title')).toBeVisible()
   })
 })

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,15 +1,48 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../src/hooks/api/useIsLoggedIn', () => ({
+  useIsLoggedIn: vi.fn(),
+}))
+
+import { useIsLoggedIn } from '../src/hooks/api/useIsLoggedIn'
 
 describe('index.tsx', () => {
-  test('should render App in root element', async () => {
+  test('should render App in root element for guest users', async () => {
     const rootElement = document.createElement('div')
     rootElement.id = 'root'
     document.body.appendChild(rootElement)
 
+    vi.mocked(useIsLoggedIn).mockReturnValue({
+      isLoggedIn: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    vi.resetModules()
     await import('../src/index')
 
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(rootElement.innerHTML).toContain('home.hero_title')
+
+    document.body.removeChild(rootElement)
+  }, 30000)
+
+  test('should render App in root element for logged in users', async () => {
+    const rootElement = document.createElement('div')
+    rootElement.id = 'root'
+    document.body.appendChild(rootElement)
+
+    vi.mocked(useIsLoggedIn).mockReturnValue({
+      isLoggedIn: true,
+      isLoading: false,
+      isError: false,
+    })
+
+    vi.resetModules()
+    await import('../src/index')
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(rootElement.innerHTML).toContain('home.hero_logged_in_title')
 
     document.body.removeChild(rootElement)
   }, 30000)


### PR DESCRIPTION
## Summary
- add dedicated hero and community sections for logged-in users
- route unauthenticated buttons to login page
- cover auth scenarios in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fefdb0428832ead32ab7bb1413d77