### PR TITLE
feat: fetch books from api via hook

### DIFF
--- a/mocks/handlers/books/books.handler.ts
+++ b/mocks/handlers/books/books.handler.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from 'msw'
+
+import { RELATIVE_API_ROUTES } from '@/api/routes'
+
+import booksResponse from './fixtures/books.json'
+
+export const booksHandler = http.get(
+  RELATIVE_API_ROUTES.BOOKS.LIST,
+  async () => {
+    await new Promise((r) => setTimeout(r, 200))
+    return HttpResponse.json(booksResponse, { status: 200 })
+  }
+)

--- a/mocks/handlers/books/fixtures/books.json
+++ b/mocks/handlers/books/fixtures/books.json
@@ -1,0 +1,17 @@
+[
+  {
+    "title": "1984",
+    "author": "George Orwell",
+    "coverUrl": "https://covers.openlibrary.org/b/id/7222246-L.jpg"
+  },
+  {
+    "title": "Brave New World",
+    "author": "Aldous Huxley",
+    "coverUrl": "https://covers.openlibrary.org/b/id/8775116-L.jpg"
+  },
+  {
+    "title": "Fahrenheit 451",
+    "author": "Ray Bradbury",
+    "coverUrl": "https://covers.openlibrary.org/b/id/11172235-L.jpg"
+  }
+]

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,12 +1,14 @@
 import { loginHandler } from './auth/login.handler'
 import { logoutHandler } from './auth/logout.handler'
 import { authStateHandler, meHandler } from './auth/me.handler'
+import { booksHandler } from './books/books.handler'
 import { contactFormHandler } from './contactForm/contactForm.handler'
 
 export const handlers = [
   loginHandler,
   logoutHandler,
-  contactFormHandler,
   authStateHandler,
   meHandler,
+  booksHandler,
+  contactFormHandler,
 ]

--- a/src/api/books/books.service.ts
+++ b/src/api/books/books.service.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/api/axios'
+import { RELATIVE_API_ROUTES } from '@/api/routes'
+
+import { Book } from './books.types'
+
+export const fetchBooks = async (): Promise<Book[]> => {
+  const response = await apiClient.get<Book[]>(RELATIVE_API_ROUTES.BOOKS.LIST)
+  return response.data
+}

--- a/src/api/books/books.types.ts
+++ b/src/api/books/books.types.ts
@@ -1,0 +1,5 @@
+export interface Book {
+  title: string
+  author: string
+  coverUrl: string
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -8,4 +8,7 @@ export const RELATIVE_API_ROUTES = {
   CONTACT_FORM: {
     SUBMIT: `/contact/submit`,
   },
+  BOOKS: {
+    LIST: `/books`,
+  },
 }

--- a/src/hooks/api/useBooks.ts
+++ b/src/hooks/api/useBooks.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchBooks } from '@/api/books/books.service'
+
+export const useBooks = () => {
+  return useQuery({ queryKey: ['books'], queryFn: fetchBooks })
+}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -7,28 +7,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
 import { HOME_URLS } from '@/constants/constants'
+import { useBooks } from '@/hooks/api/useBooks'
 import { useIsLoggedIn } from '@/hooks/api/useIsLoggedIn'
 
 import styles from './HomePage.module.scss'
-
-// Mock books
-const mockBooks = [
-  {
-    title: '1984',
-    author: 'George Orwell',
-    coverUrl: 'https://covers.openlibrary.org/b/id/7222246-L.jpg',
-  },
-  {
-    title: 'Brave New World',
-    author: 'Aldous Huxley',
-    coverUrl: 'https://covers.openlibrary.org/b/id/8775116-L.jpg',
-  },
-  {
-    title: 'Fahrenheit 451',
-    author: 'Ray Bradbury',
-    coverUrl: 'https://covers.openlibrary.org/b/id/11172235-L.jpg',
-  },
-]
 
 // Mock activity
 const mockActivities = [
@@ -49,6 +31,7 @@ const mockActivities = [
 export const HomePage = () => {
   const { t } = useTranslation()
   const { isLoggedIn, isLoading } = useIsLoggedIn()
+  const { data: books } = useBooks()
   const navigate = useNavigate()
 
   if (isLoading) return null
@@ -89,7 +72,7 @@ export const HomePage = () => {
             <button className={styles.linkButton}>{t('home.see_all')}</button>
           </div>
           <div className={styles.bookList}>
-            {mockBooks.map((book, idx) => (
+            {books?.map((book, idx) => (
               <BookCard key={idx} {...book} />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add `/books` route and service
- provide msw handler with fake books data
- use `useBooks` hook in HomePage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a015779630832eada0c09bfc79136c