### PR TITLE
feat: persist login session across refresh

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,11 +2,27 @@ import axios from 'axios'
 
 const baseURL = import.meta.env.PUBLIC_API_BASE_URL || ''
 
+const token =
+  typeof window !== 'undefined' ? localStorage.getItem('token') : null
+
 export const apiClient = axios.create({
   baseURL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
     'X-Requested-With': 'XMLHttpRequest',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
   },
 })
+
+export const setAuthToken = (token?: string) => {
+  if (typeof window === 'undefined') return
+
+  if (token) {
+    localStorage.setItem('token', token)
+    apiClient.defaults.headers.common.Authorization = `Bearer ${token}`
+  } else {
+    localStorage.removeItem('token')
+    delete apiClient.defaults.headers.common.Authorization
+  }
+}

--- a/src/hooks/api/useLogin.ts
+++ b/src/hooks/api/useLogin.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { login } from '@/api/auth/login.service'
+import { setAuthToken } from '@/api/axios'
 import { AuthQueryKeys } from '@/constants/constants'
 
 export const useLogin = () => {
@@ -9,9 +10,11 @@ export const useLogin = () => {
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
+      setAuthToken(data.token)
       queryClient.setQueryData([AuthQueryKeys.AUTH], data)
     },
     onError: () => {
+      setAuthToken()
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
     },
   })

--- a/src/hooks/api/useLogout.ts
+++ b/src/hooks/api/useLogout.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 import { logout } from '@/api/auth/logout.service'
+import { setAuthToken } from '@/api/axios'
 import { AuthQueryKeys, HOME_URLS } from '@/constants/constants'
 
 export const useLogout = () => {
@@ -12,10 +13,12 @@ export const useLogout = () => {
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
+      setAuthToken()
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
       navigate(`/${HOME_URLS.LOGIN}`, { replace: true })
     },
     onError: (error: Error) => {
+      setAuthToken()
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
       toast.error(`Error: ${error.message}`)
     },


### PR DESCRIPTION
## Summary
- save auth token in localStorage and attach to axios headers
- update login/logout hooks to set or clear token

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a019a4e8a8832eb7197c393b9fd6ae