### PR TITLE
feat: add auth provider context

### DIFF
--- a/mocks/constants/constants.ts
+++ b/mocks/constants/constants.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_EMAIL = 'user@entrelibros.com'
+export const DEFAULT_EMAIL = 'u@u'
 
 export const DEFAULT_PASS = ''

--- a/mocks/handlers/auth/login.handler.ts
+++ b/mocks/handlers/auth/login.handler.ts
@@ -29,7 +29,7 @@ export const loginHandler = http.post(
     return HttpResponse.json(successResponse, {
       status: 200,
       headers: {
-        'Set-Cookie': `authToken=${successResponse.token}; HttpOnly; Secure`,
+        'Set-Cookie': `authToken=${successResponse.token}; Path=/; HttpOnly; Secure; SameSite=Strict`,
         'Content-Type': 'application/json',
       },
     })

--- a/mocks/handlers/auth/login.handler.ts
+++ b/mocks/handlers/auth/login.handler.ts
@@ -28,8 +28,9 @@ export const loginHandler = http.post(
     setLoggedInState(true)
     return HttpResponse.json(successResponse, {
       status: 200,
+      // HttpOnly should be set in the server, but won't be use in development
       headers: {
-        'Set-Cookie': `authToken=${successResponse.token}; Path=/; HttpOnly; Secure; SameSite=Strict`,
+        'Set-Cookie': `sessionToken=${successResponse.token}; Path=/; Secure; SameSite=Strict`,
         'Content-Type': 'application/json',
       },
     })

--- a/mocks/handlers/auth/login.handler.ts
+++ b/mocks/handlers/auth/login.handler.ts
@@ -28,9 +28,10 @@ export const loginHandler = http.post(
     setLoggedInState(true)
     return HttpResponse.json(successResponse, {
       status: 200,
-      // HttpOnly should be set in the server, but won't be use in development
+      // HttpOnly should be set in the server, but won't be used in development
       headers: {
-        'Set-Cookie': `sessionToken=${successResponse.token}; Path=/; Secure; SameSite=Strict`,
+        // Secure flag omitted so that the cookie is sent over HTTP in development
+        'Set-Cookie': `sessionToken=${successResponse.token}; Path=/; SameSite=Strict`,
         'Content-Type': 'application/json',
       },
     })

--- a/mocks/handlers/auth/logout.handler.ts
+++ b/mocks/handlers/auth/logout.handler.ts
@@ -11,7 +11,7 @@ export const logoutHandler = http.post(RELATIVE_API_ROUTES.AUTH.LOGOUT, () => {
     status: 200,
     headers: {
       'Set-Cookie':
-        'authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict',
+        'sessionToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Strict',
       'Content-Type': 'application/json',
     },
   })

--- a/mocks/handlers/auth/logout.handler.ts
+++ b/mocks/handlers/auth/logout.handler.ts
@@ -11,7 +11,7 @@ export const logoutHandler = http.post(RELATIVE_API_ROUTES.AUTH.LOGOUT, () => {
     status: 200,
     headers: {
       'Set-Cookie':
-        'authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure',
+        'authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict',
       'Content-Type': 'application/json',
     },
   })

--- a/mocks/handlers/auth/me.handler.ts
+++ b/mocks/handlers/auth/me.handler.ts
@@ -41,7 +41,7 @@ export const authStateHandler = http.get('/_msw/auth/state', ({ request }) => {
 /**
  * /auth/me — returns 200 with user or 401 based on:
  *  1) AUTH_OVERRIDE if not "auto"
- *  2) Otherwise, presence of "authToken" cookie (set by /auth/login handler)
+ *  2) Otherwise, presence of "sessionToken" cookie (set by /auth/login handler)
  */
 export const meHandler = http.get(
   RELATIVE_API_ROUTES.AUTH.ME,
@@ -64,7 +64,7 @@ export const meHandler = http.get(
 
     // 3) Cookie-based default
     const cookieHeader = request.headers.get('cookie')
-    const token = getCookie('authToken', cookieHeader)
+    const token = getCookie('sessionToken', cookieHeader)
     if (token) {
       return HttpResponse.json(successUser, { status: 200 })
     }

--- a/mocks/handlers/auth/me.handler.ts
+++ b/mocks/handlers/auth/me.handler.ts
@@ -15,13 +15,6 @@ export const setLoggedInState = (next: boolean) => {
   IS_LOGGED_IN = next
 }
 
-function getCookie(name: string, cookieHeader: string | null): string | null {
-  if (!cookieHeader) return null
-  const parts = cookieHeader.split(';').map((c) => c.trim())
-  const found = parts.find((c) => c.startsWith(`${name}=`))
-  return found ? decodeURIComponent(found.split('=').slice(1).join('=')) : null
-}
-
 /**
  * Runtime toggle (no app code changes needed).
  * Usage from browser console:
@@ -45,7 +38,7 @@ export const authStateHandler = http.get('/_msw/auth/state', ({ request }) => {
  */
 export const meHandler = http.get(
   RELATIVE_API_ROUTES.AUTH.ME,
-  ({ request }) => {
+  ({ request, cookies }) => {
     // 1) Override wins
     if (AUTH_OVERRIDE === 'logged-in') {
       return HttpResponse.json(successUser, { status: 200 })
@@ -63,8 +56,7 @@ export const meHandler = http.get(
     }
 
     // 3) Cookie-based default
-    const cookieHeader = request.headers.get('cookie')
-    const token = getCookie('sessionToken', cookieHeader)
+    const token = cookies.sessionToken
     if (token) {
       return HttpResponse.json(successUser, { status: 200 })
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,15 +12,6 @@ const queryClient = new QueryClient()
 
 const App = () => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <ThemeProvider>
-          <div>
-            <AppRoutes />
-            <Toaster />
-          </div>
-        </ThemeProvider>
-      </AuthProvider>
     <AuthProvider>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,16 +12,16 @@ const queryClient = new QueryClient()
 
 const App = () => {
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
         <ThemeProvider>
           <div>
             <AppRoutes />
             <Toaster />
           </div>
         </ThemeProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from '@components/ui/toaster/Toaster'
 import { ThemeProvider } from '@contexts/theme/ThemeContext'
+import { AuthProvider } from '@contexts/auth/AuthContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 
@@ -12,12 +13,14 @@ const queryClient = new QueryClient()
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <div>
-          <AppRoutes />
-          <Toaster />
-        </div>
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <div>
+            <AppRoutes />
+            <Toaster />
+          </div>
+        </ThemeProvider>
+      </AuthProvider>
     </QueryClientProvider>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,16 @@ const App = () => {
           </div>
         </ThemeProvider>
       </AuthProvider>
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <div>
+            <AppRoutes />
+            <Toaster />
+          </div>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </AuthProvider>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Toaster } from '@components/ui/toaster/Toaster'
-import { ThemeProvider } from '@contexts/theme/ThemeContext'
 import { AuthProvider } from '@contexts/auth/AuthContext'
+import { ThemeProvider } from '@contexts/theme/ThemeContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 

--- a/src/api/auth/me.service.ts
+++ b/src/api/auth/me.service.ts
@@ -2,6 +2,8 @@ import { apiClient } from '@/api/axios'
 import { RELATIVE_API_ROUTES } from '@/api/routes'
 
 export const fetchMe = async () => {
-  const response = await apiClient.get(RELATIVE_API_ROUTES.AUTH.ME)
+  const response = await apiClient.get(RELATIVE_API_ROUTES.AUTH.ME, {
+    withCredentials: true,
+  })
   return response.data
 }

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,32 +1,24 @@
 import { fetchMe } from '@api/auth/me.service'
-import { createContext, useContext, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createContext, useContext } from 'react'
+
+import { AuthQueryKeys } from '@/constants/constants'
 
 import type { AuthContextType, AuthProviderProps } from './AuthContext.types'
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  const [user, setUser] = useState<AuthContextType['user']>(null)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const loadUser = async () => {
-      try {
-        const me = await fetchMe()
-        setUser(me)
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to fetch user:', error)
-        setUser(null)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    loadUser()
-  }, [])
+  const { data: user, isLoading } = useQuery({
+    queryKey: [AuthQueryKeys.AUTH],
+    queryFn: fetchMe,
+    retry: false,
+  })
 
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading }}>
+    <AuthContext.Provider
+      value={{ user: user ?? null, isAuthenticated: !!user, isLoading }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -15,6 +15,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         const me = await fetchMe()
         setUser(me)
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.error('Failed to fetch user:', error)
         setUser(null)
       } finally {

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+import { fetchMe } from '@api/auth/me.service'
+import type { AuthContextType, AuthProviderProps } from './AuthContext.types'
+
+export const AuthContext = createContext<AuthContextType | undefined>(
+  undefined
+)
+
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+  const [user, setUser] = useState<AuthContextType['user']>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        const me = await fetchMe()
+        setUser(me)
+      } catch {
+        setUser(null)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    loadUser()
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,11 +1,9 @@
+import { fetchMe } from '@api/auth/me.service'
 import { createContext, useContext, useEffect, useState } from 'react'
 
-import { fetchMe } from '@api/auth/me.service'
 import type { AuthContextType, AuthProviderProps } from './AuthContext.types'
 
-export const AuthContext = createContext<AuthContextType | undefined>(
-  undefined
-)
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<AuthContextType['user']>(null)
@@ -39,4 +37,3 @@ export const useAuth = () => {
   }
   return context
 }
-

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -14,7 +14,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       try {
         const me = await fetchMe()
         setUser(me)
-      } catch {
+      } catch (error) {
+        console.error('Failed to fetch user:', error)
         setUser(null)
       } finally {
         setIsLoading(false)

--- a/src/contexts/auth/AuthContext.types.ts
+++ b/src/contexts/auth/AuthContext.types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+
+export type AuthUser = unknown | null
+
+export type AuthContextType = {
+  user: AuthUser
+  isAuthenticated: boolean
+  isLoading: boolean
+}
+
+export type AuthProviderProps = {
+  children: ReactNode
+}
+

--- a/src/contexts/auth/AuthContext.types.ts
+++ b/src/contexts/auth/AuthContext.types.ts
@@ -1,12 +1,8 @@
 import type { ReactNode } from 'react'
 
-export type AuthUser = unknown | null
-
-export type AuthContextType = {
 export interface AuthUser {
   id: string
   email: string
-  // Add other properties as needed, e.g. name, roles, etc.
 }
 
 export type MaybeAuthUser = AuthUser | null

--- a/src/contexts/auth/AuthContext.types.ts
+++ b/src/contexts/auth/AuthContext.types.ts
@@ -11,4 +11,3 @@ export type AuthContextType = {
 export type AuthProviderProps = {
   children: ReactNode
 }
-

--- a/src/contexts/auth/AuthContext.types.ts
+++ b/src/contexts/auth/AuthContext.types.ts
@@ -3,7 +3,15 @@ import type { ReactNode } from 'react'
 export type AuthUser = unknown | null
 
 export type AuthContextType = {
-  user: AuthUser
+export interface AuthUser {
+  id: string
+  email: string
+  // Add other properties as needed, e.g. name, roles, etc.
+}
+
+export type MaybeAuthUser = AuthUser | null
+export type AuthContextType = {
+  user: MaybeAuthUser
   isAuthenticated: boolean
   isLoading: boolean
 }

--- a/src/hooks/api/useIsLoggedIn.ts
+++ b/src/hooks/api/useIsLoggedIn.ts
@@ -1,9 +1,11 @@
 import { fetchMe } from '@api/auth/me.service'
 import { useQuery } from '@tanstack/react-query'
 
+import { AuthQueryKeys } from '@/constants/constants'
+
 export const useIsLoggedIn = () => {
   const { data, isError, isLoading } = useQuery({
-    queryKey: ['me'],
+    queryKey: [AuthQueryKeys.AUTH],
     queryFn: fetchMe,
     retry: false,
   })

--- a/src/hooks/api/useLogin.ts
+++ b/src/hooks/api/useLogin.ts
@@ -9,7 +9,7 @@ export const useLogin = () => {
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
-      queryClient.setQueryData([AuthQueryKeys.AUTH], data)
+      queryClient.setQueryData([AuthQueryKeys.AUTH], data.user)
     },
     onError: () => {
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,12 +3,12 @@ import { CommunitySectionLoggedIn } from '@components/home/CommunitySectionLogge
 import { HeroLoggedIn } from '@components/home/HeroLoggedIn'
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
 import { UserActivityItem } from '@components/user/UserActivityItem'
+import { useAuth } from '@contexts/auth/AuthContext'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
 import { HOME_URLS } from '@/constants/constants'
 import { useBooks } from '@/hooks/api/useBooks'
-import { useAuth } from '@contexts/auth/AuthContext'
 
 import styles from './HomePage.module.scss'
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { HOME_URLS } from '@/constants/constants'
 import { useBooks } from '@/hooks/api/useBooks'
-import { useIsLoggedIn } from '@/hooks/api/useIsLoggedIn'
+import { useAuth } from '@contexts/auth/AuthContext'
 
 import styles from './HomePage.module.scss'
 
@@ -30,7 +30,7 @@ const mockActivities = [
 
 export const HomePage = () => {
   const { t } = useTranslation()
-  const { isLoggedIn, isLoading } = useIsLoggedIn()
+  const { isAuthenticated, isLoading } = useAuth()
   const { data: books } = useBooks()
   const navigate = useNavigate()
 
@@ -40,7 +40,7 @@ export const HomePage = () => {
     <BaseLayout>
       <div className={styles.homeWrapper}>
         {/* HERO */}
-        {isLoggedIn ? (
+        {isAuthenticated ? (
           <HeroLoggedIn />
         ) : (
           <section className={styles.hero}>
@@ -91,7 +91,7 @@ export const HomePage = () => {
         </section>
 
         {/* CTA COMUNIDAD */}
-        {isLoggedIn ? (
+        {isAuthenticated ? (
           <CommunitySectionLoggedIn />
         ) : (
           <section className={styles.communitySection}>

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -2,32 +2,27 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 import App from '../src/App'
-import { useIsLoggedIn } from '../src/hooks/api/useIsLoggedIn'
+import { fetchMe } from '../src/api/auth/me.service'
+vi.mock('../src/hooks/api/useBooks', () => ({
+  useBooks: () => ({ data: [] }),
+}))
 
-vi.mock('../src/hooks/api/useIsLoggedIn')
+vi.mock('../src/api/auth/me.service', () => ({ fetchMe: vi.fn() }))
 
 describe('App Component', () => {
-  test('renders correctly for guest users', () => {
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: false,
-      isLoading: false,
-      isError: false,
-    })
+  test('renders correctly for guest users', async () => {
+    vi.mocked(fetchMe).mockRejectedValueOnce(new Error('unauthenticated'))
 
     render(<App />)
 
-    expect(screen.getByText('home.hero_title')).toBeVisible()
+    expect(await screen.findByText('home.hero_title')).toBeVisible()
   })
 
-  test('renders correctly for logged in users', () => {
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: true,
-      isLoading: false,
-      isError: false,
-    })
+  test('renders correctly for logged in users', async () => {
+    vi.mocked(fetchMe).mockResolvedValueOnce({ id: 1 })
 
     render(<App />)
 
-    expect(screen.getByText('home.hero_logged_in_title')).toBeVisible()
+    expect(await screen.findByText('home.hero_logged_in_title')).toBeVisible()
   })
 })

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-import App from '../src/App'
 import { fetchMe } from '../src/api/auth/me.service'
+import App from '../src/App'
 vi.mock('../src/hooks/api/useBooks', () => ({
   useBooks: () => ({ data: [] }),
 }))

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi } from 'vitest'
 import { screen, act } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
 
 vi.mock('../src/api/auth/me.service', () => ({
   fetchMe: vi.fn(),
@@ -26,7 +26,9 @@ describe('index.tsx', () => {
       await import('../src/index')
     })
 
-    expect(await screen.findByText('home.hero_title', { timeout: 3000 })).toBeTruthy()
+    expect(
+      await screen.findByText('home.hero_title', { timeout: 3000 })
+    ).toBeTruthy()
 
     document.body.removeChild(rootElement)
   }, 30000)
@@ -65,7 +67,9 @@ describe('index.tsx', () => {
     await act(async () => {
       await import('../src/index')
     })
-    expect(await screen.findByText('home.hero_title', { timeout: 3000 })).toBeTruthy()
+    expect(
+      await screen.findByText('home.hero_title', { timeout: 3000 })
+    ).toBeTruthy()
     expect(worker.start).toHaveBeenCalled()
 
     document.body.removeChild(rootElement)

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,13 +1,17 @@
 import { describe, expect, test, vi } from 'vitest'
+import { screen, act } from '@testing-library/react'
 
-vi.mock('../src/hooks/api/useIsLoggedIn', () => ({
-  useIsLoggedIn: vi.fn(),
+vi.mock('../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn(),
+}))
+vi.mock('../src/hooks/api/useBooks', () => ({
+  useBooks: () => ({ data: [] }),
 }))
 vi.mock('../mocks/browser', () => ({
   worker: { start: vi.fn() },
 }))
 
-import { useIsLoggedIn } from '../src/hooks/api/useIsLoggedIn'
+import { fetchMe } from '../src/api/auth/me.service'
 
 describe('index.tsx', () => {
   test('should render App in root element for guest users', async () => {
@@ -15,17 +19,14 @@ describe('index.tsx', () => {
     rootElement.id = 'root'
     document.body.appendChild(rootElement)
 
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: false,
-      isLoading: false,
-      isError: false,
-    })
+    vi.mocked(fetchMe).mockRejectedValue(new Error('unauthenticated'))
 
     vi.resetModules()
-    await import('../src/index')
+    await act(async () => {
+      await import('../src/index')
+    })
 
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(rootElement.innerHTML).toContain('home.hero_title')
+    expect(await screen.findByText('home.hero_title', { timeout: 3000 })).toBeTruthy()
 
     document.body.removeChild(rootElement)
   }, 30000)
@@ -35,17 +36,16 @@ describe('index.tsx', () => {
     rootElement.id = 'root'
     document.body.appendChild(rootElement)
 
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: true,
-      isLoading: false,
-      isError: false,
-    })
+    vi.mocked(fetchMe).mockResolvedValue({ id: 1 })
 
     vi.resetModules()
-    await import('../src/index')
+    await act(async () => {
+      await import('../src/index')
+    })
 
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(rootElement.innerHTML).toContain('home.hero_logged_in_title')
+    expect(
+      await screen.findByText('home.hero_logged_in_title', { timeout: 3000 })
+    ).toBeTruthy()
 
     document.body.removeChild(rootElement)
   }, 30000)
@@ -60,15 +60,12 @@ describe('index.tsx', () => {
 
     vi.resetModules()
     const { worker } = await import('../mocks/browser')
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: false,
-      isLoading: false,
-      isError: false,
+    vi.mocked(fetchMe).mockRejectedValue(new Error('unauthenticated'))
+
+    await act(async () => {
+      await import('../src/index')
     })
-
-    await import('../src/index')
-
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(await screen.findByText('home.hero_title', { timeout: 3000 })).toBeTruthy()
     expect(worker.start).toHaveBeenCalled()
 
     document.body.removeChild(rootElement)

--- a/tests/pages/books/BooksPage.test.tsx
+++ b/tests/pages/books/BooksPage.test.tsx
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { BooksPage } from '../../../src/pages/books/BooksPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/community/CommunityPage.test.tsx
+++ b/tests/pages/community/CommunityPage.test.tsx
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { CommunityPage } from '../../../src/pages/community/CommunityPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/contact/ContactPage.test.tsx
+++ b/tests/pages/contact/ContactPage.test.tsx
@@ -1,5 +1,9 @@
 import { screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { ContactPage } from '../../../src/pages/contact/ContactPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/home/HomePage.test.tsx
+++ b/tests/pages/home/HomePage.test.tsx
@@ -1,44 +1,35 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/hooks/api/useIsLoggedIn', () => ({
-  useIsLoggedIn: vi.fn(),
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn(),
+}))
+vi.mock('../../../src/hooks/api/useBooks', () => ({
+  useBooks: () => ({ data: [] }),
 }))
 
-import { useIsLoggedIn } from '../../../src/hooks/api/useIsLoggedIn'
+import { fetchMe } from '../../../src/api/auth/me.service'
 import { HomePage } from '../../../src/pages/home/HomePage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('HomePage', () => {
   test('returns null while loading', () => {
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: false,
-      isLoading: true,
-      isError: false,
-    })
+    vi.mocked(fetchMe).mockReturnValue(new Promise(() => {}))
     const { container } = renderWithProviders(<HomePage />)
     expect(container.firstChild).toBeNull()
   })
 
-  test('renders guest hero when not logged in', () => {
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: false,
-      isLoading: false,
-      isError: false,
-    })
+  test('renders guest hero when not logged in', async () => {
+    vi.mocked(fetchMe).mockRejectedValueOnce(new Error('unauthenticated'))
     renderWithProviders(<HomePage />)
-    expect(screen.getByText('home.hero_title')).toBeVisible()
+    expect(await screen.findByText('home.hero_title')).toBeVisible()
     fireEvent.click(screen.getByText('home.hero_cta'))
     fireEvent.click(screen.getByText('home.explore_community'))
   })
 
-  test('renders logged in hero', () => {
-    vi.mocked(useIsLoggedIn).mockReturnValue({
-      isLoggedIn: true,
-      isLoading: false,
-      isError: false,
-    })
+  test('renders logged in hero', async () => {
+    vi.mocked(fetchMe).mockResolvedValueOnce({ id: 1 })
     renderWithProviders(<HomePage />)
-    expect(screen.getByText('home.hero_logged_in_title')).toBeVisible()
+    expect(await screen.findByText('home.hero_logged_in_title')).toBeVisible()
   })
 })

--- a/tests/pages/login/LoginPage.test.tsx
+++ b/tests/pages/login/LoginPage.test.tsx
@@ -1,6 +1,10 @@
 import { screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
+
 vi.mock('../../../src/components/login/LoginForm', () => ({
   LoginForm: ({ onSubmit }: { onSubmit?: (data: unknown) => void }) => {
     onSubmit?.({})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
 // Mock SVGs
 vi.mock('.*\\.svg$', () => ({
@@ -22,4 +22,13 @@ vi.mock('react-i18next', async () => {
       init: () => {},
     },
   }
+})
+
+// Clear cookies after each test to avoid cross-test contamination
+afterEach(() => {
+  document.cookie.split(';').forEach((cookie) => {
+    const eqPos = cookie.indexOf('=')
+    const name = eqPos > -1 ? cookie.slice(0, eqPos).trim() : cookie.trim()
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
+  })
 })

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react'
 import { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
-import { ThemeProvider } from '../src/contexts/theme/ThemeContext'
 import { AuthProvider } from '../src/contexts/auth/AuthContext'
+import { ThemeProvider } from '../src/contexts/theme/ThemeContext'
 
 export const renderWithProviders = (ui: ReactElement) => {
   const queryClient = new QueryClient()

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -4,13 +4,16 @@ import { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
 import { ThemeProvider } from '../src/contexts/theme/ThemeContext'
+import { AuthProvider } from '../src/contexts/auth/AuthContext'
 
 export const renderWithProviders = (ui: ReactElement) => {
   const queryClient = new QueryClient()
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider>{ui}</ThemeProvider>
+        <AuthProvider>
+          <ThemeProvider>{ui}</ThemeProvider>
+        </AuthProvider>
       </QueryClientProvider>
     </MemoryRouter>
   )


### PR DESCRIPTION
## Summary
- add AuthProvider to manage user session state
- replace useIsLoggedIn usage with new auth context
- update tests to mock session fetches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01e3e9404832eb8c83424afd618ba