### PR TITLE
refactor auth context to use cookie-based session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,16 +12,16 @@ const queryClient = new QueryClient()
 
 const App = () => {
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
         <ThemeProvider>
           <div>
             <AppRoutes />
             <Toaster />
           </div>
         </ThemeProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,32 +1,22 @@
 import { fetchMe } from '@api/auth/me.service'
-import { createContext, useContext, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createContext, useContext } from 'react'
+
+import { AuthQueryKeys } from '@/constants/constants'
 
 import type { AuthContextType, AuthProviderProps } from './AuthContext.types'
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  const [user, setUser] = useState<AuthContextType['user']>(null)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const loadUser = async () => {
-      try {
-        const me = await fetchMe()
-        setUser(me)
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to fetch user:', error)
-        setUser(null)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    loadUser()
-  }, [])
+  const { data: user, isLoading } = useQuery({
+    queryKey: [AuthQueryKeys.AUTH],
+    queryFn: fetchMe,
+    retry: false,
+  })
 
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading }}>
+    <AuthContext.Provider value={{ user: user ?? null, isAuthenticated: !!user, isLoading }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -16,7 +16,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   })
 
   return (
-    <AuthContext.Provider value={{ user: user ?? null, isAuthenticated: !!user, isLoading }}>
+    <AuthContext.Provider
+      value={{ user: user ?? null, isAuthenticated: !!user, isLoading }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/src/hooks/api/useIsLoggedIn.ts
+++ b/src/hooks/api/useIsLoggedIn.ts
@@ -1,9 +1,11 @@
 import { fetchMe } from '@api/auth/me.service'
 import { useQuery } from '@tanstack/react-query'
 
+import { AuthQueryKeys } from '@/constants/constants'
+
 export const useIsLoggedIn = () => {
   const { data, isError, isLoading } = useQuery({
-    queryKey: ['me'],
+    queryKey: [AuthQueryKeys.AUTH],
     queryFn: fetchMe,
     retry: false,
   })

--- a/src/hooks/api/useLogin.ts
+++ b/src/hooks/api/useLogin.ts
@@ -9,7 +9,7 @@ export const useLogin = () => {
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
-      queryClient.setQueryData([AuthQueryKeys.AUTH], data)
+      queryClient.setQueryData([AuthQueryKeys.AUTH], data.user)
     },
     onError: () => {
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })

--- a/tests/pages/books/BooksPage.test.tsx
+++ b/tests/pages/books/BooksPage.test.tsx
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { BooksPage } from '../../../src/pages/books/BooksPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/community/CommunityPage.test.tsx
+++ b/tests/pages/community/CommunityPage.test.tsx
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { CommunityPage } from '../../../src/pages/community/CommunityPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/contact/ContactPage.test.tsx
+++ b/tests/pages/contact/ContactPage.test.tsx
@@ -1,5 +1,9 @@
 import { screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
 
 import { ContactPage } from '../../../src/pages/contact/ContactPage'
 import { renderWithProviders } from '../../test-utils'

--- a/tests/pages/login/LoginPage.test.tsx
+++ b/tests/pages/login/LoginPage.test.tsx
@@ -1,6 +1,10 @@
 import { screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
+
 vi.mock('../../../src/components/login/LoginForm', () => ({
   LoginForm: ({ onSubmit }: { onSubmit?: (data: unknown) => void }) => {
     onSubmit?.({})


### PR DESCRIPTION
## Summary
- replace auth context state with react-query using `fetchMe`
- set auth query data on login and share key across hooks
- wrap app with `QueryClientProvider` before `AuthProvider`
- mock auth in page tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1ed3fdc832e810bd0c3d0075fe7