### PR TITLE
Use cookie-based auth and clear test cookies

### DIFF
--- a/mocks/handlers/auth/login.handler.ts
+++ b/mocks/handlers/auth/login.handler.ts
@@ -29,7 +29,7 @@ export const loginHandler = http.post(
     return HttpResponse.json(successResponse, {
       status: 200,
       headers: {
-        'Set-Cookie': `authToken=${successResponse.token}; HttpOnly; Secure`,
+        'Set-Cookie': `authToken=${successResponse.token}; Path=/; HttpOnly; Secure; SameSite=Strict`,
         'Content-Type': 'application/json',
       },
     })

--- a/mocks/handlers/auth/logout.handler.ts
+++ b/mocks/handlers/auth/logout.handler.ts
@@ -11,7 +11,7 @@ export const logoutHandler = http.post(RELATIVE_API_ROUTES.AUTH.LOGOUT, () => {
     status: 200,
     headers: {
       'Set-Cookie':
-        'authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure',
+        'authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict',
       'Content-Type': 'application/json',
     },
   })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
 // Mock SVGs
 vi.mock('.*\\.svg$', () => ({
@@ -22,4 +22,13 @@ vi.mock('react-i18next', async () => {
       init: () => {},
     },
   }
+})
+
+// Clear cookies after each test to avoid cross-test contamination
+afterEach(() => {
+  document.cookie.split(';').forEach((cookie) => {
+    const eqPos = cookie.indexOf('=')
+    const name = eqPos > -1 ? cookie.slice(0, eqPos).trim() : cookie.trim()
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
+  })
 })


### PR DESCRIPTION
## Summary
- set auth token cookies with Path, HttpOnly, Secure and SameSite=Strict in mock login/logout handlers
- clear cookies after each test instead of clearing localStorage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0aa17f0cc832e82fdf9bc51eacd6d