### PR TITLE
Clear session cookie on logout

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -9,3 +9,5 @@ export const HOME_URLS = {
   CONTACT: 'contact',
   LOGIN: 'login',
 } as const
+
+export const AUTH_COOKIE_NAME = 'sessionToken' as const

--- a/src/hooks/api/useLogout.ts
+++ b/src/hooks/api/useLogout.ts
@@ -3,19 +3,29 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 import { logout } from '@/api/auth/logout.service'
-import { AuthQueryKeys, HOME_URLS } from '@/constants/constants'
+import {
+  AUTH_COOKIE_NAME,
+  AuthQueryKeys,
+  HOME_URLS,
+} from '@/constants/constants'
 
 export const useLogout = () => {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
 
+  const clearAuthCookie = () => {
+    document.cookie = `${AUTH_COOKIE_NAME}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  }
+
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
+      clearAuthCookie()
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
       navigate(`/${HOME_URLS.LOGIN}`, { replace: true })
     },
     onError: (error: Error) => {
+      clearAuthCookie()
       queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
       toast.error(`Error: ${error.message}`)
     },

--- a/tests/hooks/api/useLogout.test.tsx
+++ b/tests/hooks/api/useLogout.test.tsx
@@ -1,0 +1,34 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, test, vi } from 'vitest'
+
+import { AUTH_COOKIE_NAME } from '../../../src/constants/constants'
+import { useLogout } from '../../../src/hooks/api/useLogout'
+
+vi.mock('../../../src/api/auth/logout.service', () => ({
+  logout: vi.fn().mockResolvedValue(undefined),
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>
+    <QueryClientProvider client={new QueryClient()}>
+      {children}
+    </QueryClientProvider>
+  </MemoryRouter>
+)
+
+describe('useLogout', () => {
+  test('clears auth cookie on logout', async () => {
+    document.cookie = `${AUTH_COOKIE_NAME}=token; path=/`
+
+    const { result } = renderHook(() => useLogout(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync()
+    })
+
+    expect(document.cookie).not.toContain(AUTH_COOKIE_NAME)
+  })
+})
+


### PR DESCRIPTION
## Summary
- ensure logout clears session cookie and auth query cache
- add test covering logout cookie cleanup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16478bfcc832e8b44650d3969cd97