### PR TITLE
feat: add explore books page with tabs and book badges

### DIFF
--- a/src/assets/i18n/locales/en/common.json
+++ b/src/assets/i18n/locales/en/common.json
@@ -69,5 +69,39 @@
     "added": "Ofreciste",
     "exchanged": "Intercambiaste",
     "cover_alt": "Portada de {{title}}"
+  },
+  "booksPage": {
+    "title": "Explore books",
+    "search_placeholder": "Search by title, author, ISBN",
+    "filter": {
+      "near": "Near",
+      "available": "Available"
+    },
+    "publish_button": "Publish a book",
+    "tabs": {
+      "mine": "My books",
+      "for_trade": "Available for trade",
+      "seeking": "Seeking",
+      "for_sale": "For sale",
+      "see_all": "See all"
+    },
+    "empty": {
+      "mine": "You haven't added books yet.",
+      "trade": "You haven't listed books for trade yet.",
+      "seeking": "No books in your wish list.",
+      "sale": "You don't have books for sale yet."
+    },
+    "status": {
+      "available": "Available",
+      "reserved": "Reserved",
+      "sold": "Sold",
+      "exchanged": "Exchanged"
+    },
+    "badge": {
+      "for_sale": "For sale · ${{price}}",
+      "for_trade": "Trade",
+      "seeking": "Seeking"
+    },
+    "cover_alt": "Cover of {{title}}"
   }
 }

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -69,5 +69,39 @@
     "added": "You added",
     "exchanged": "You exchanged",
     "cover_alt": "Cover of {{title}}"
+  },
+  "booksPage": {
+    "title": "Explorar libros",
+    "search_placeholder": "Buscar por título, autor, ISBN",
+    "filter": {
+      "near": "Near",
+      "available": "Available"
+    },
+    "publish_button": "Publicar un libro",
+    "tabs": {
+      "mine": "Mis libros",
+      "for_trade": "Disponibles para intercambio",
+      "seeking": "Buscando",
+      "for_sale": "A la venta",
+      "see_all": "Ver todos"
+    },
+    "empty": {
+      "mine": "Aún no cargaste libros.",
+      "trade": "Aún no publicaste libros para intercambio. Cargá el primero.",
+      "seeking": "No hay libros en tu lista de deseos.",
+      "sale": "Aún no tenés libros a la venta."
+    },
+    "status": {
+      "available": "Disponible",
+      "reserved": "Reservado",
+      "sold": "Vendido",
+      "exchanged": "Intercambiado"
+    },
+    "badge": {
+      "for_sale": "A la venta · ${{price}}",
+      "for_trade": "Intercambio",
+      "seeking": "Buscando"
+    },
+    "cover_alt": "Portada de {{title}}"
   }
 }

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -74,7 +74,7 @@
     "title": "Explorar libros",
     "search_placeholder": "Buscar por título, autor, ISBN",
     "filter": {
-      "near": "Near",
+      "near": "Cerca",
       "available": "Available"
     },
     "publish_button": "Publicar un libro",

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -75,7 +75,7 @@
     "search_placeholder": "Buscar por título, autor, ISBN",
     "filter": {
       "near": "Cerca",
-      "available": "Available"
+      "available": "Disponible"
     },
     "publish_button": "Publicar un libro",
     "tabs": {

--- a/src/components/book/BookCard.module.scss
+++ b/src/components/book/BookCard.module.scss
@@ -48,14 +48,17 @@
   padding: 0 $spacing-1;
   border-radius: rem(4px);
   width: fit-content;
+
   &.available {
     background-color: var(--color-success);
     color: #fff;
   }
+
   &.reserved {
     background-color: var(--color-warning);
     color: #000;
   }
+
   &.sold,
   &.exchanged {
     background-color: var(--color-neutral-500);

--- a/src/components/book/BookCard.module.scss
+++ b/src/components/book/BookCard.module.scss
@@ -40,3 +40,63 @@
   color: var(--text-secondary);
   margin-top: rem(4px);
 }
+
+.status {
+  margin-top: rem(4px);
+  font-size: 0.75rem;
+  font-weight: $font-weight-medium;
+  padding: 0 $spacing-1;
+  border-radius: rem(4px);
+  width: fit-content;
+  &.available {
+    background-color: var(--color-success);
+    color: #fff;
+  }
+  &.reserved {
+    background-color: var(--color-warning);
+    color: #000;
+  }
+  &.sold,
+  &.exchanged {
+    background-color: var(--color-neutral-500);
+    color: #fff;
+  }
+}
+
+.condition {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: rem(4px);
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem(4px);
+  margin-top: rem(6px);
+}
+
+.sale,
+.trade,
+.seeking {
+  font-size: 0.75rem;
+  padding: rem(2px) rem(4px);
+  border-radius: rem(12px);
+  font-weight: $font-weight-medium;
+  width: fit-content;
+}
+
+.sale {
+  background-color: var(--color-success);
+  color: #fff;
+}
+
+.trade {
+  background-color: var(--color-info);
+  color: #fff;
+}
+
+.seeking {
+  background-color: #f48fb1;
+  color: #fff;
+}

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -21,7 +21,8 @@ export const BookCard: React.FC<BookCardProps> = ({
   const renderTradePreferences = () => {
     if (!tradePreferences || tradePreferences.length === 0) return null
     const shown = tradePreferences.slice(0, 3).join(', ')
-    const extra = tradePreferences.length > 3 ? ` +${tradePreferences.length - 3}` : ''
+    const extra =
+      tradePreferences.length > 3 ? ` +${tradePreferences.length - 3}` : ''
     return `${shown}${extra}`
   }
 
@@ -58,7 +59,11 @@ export const BookCard: React.FC<BookCardProps> = ({
               )}
             </span>
           )}
-          {isSeeking && <span className={styles.seeking}>{t('booksPage.badge.seeking')}</span>}
+          {isSeeking && (
+            <span className={styles.seeking}>
+              {t('booksPage.badge.seeking')}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -1,5 +1,6 @@
 import { BookCardProps } from '@components/book/BookCard.types'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import styles from './BookCard.module.scss'
 
@@ -7,13 +8,58 @@ export const BookCard: React.FC<BookCardProps> = ({
   title,
   author,
   coverUrl,
+  condition,
+  status,
+  isForSale,
+  price,
+  isForTrade,
+  tradePreferences,
+  isSeeking,
 }) => {
+  const { t } = useTranslation()
+
+  const renderTradePreferences = () => {
+    if (!tradePreferences || tradePreferences.length === 0) return null
+    const shown = tradePreferences.slice(0, 3).join(', ')
+    const extra = tradePreferences.length > 3 ? ` +${tradePreferences.length - 3}` : ''
+    return `${shown}${extra}`
+  }
+
   return (
     <div className={styles.card}>
-      <img src={coverUrl} alt={title} className={styles.cover} />
+      <img
+        src={coverUrl}
+        alt={t('booksPage.cover_alt', { title })}
+        className={styles.cover}
+      />
       <div className={styles.info}>
         <h3 className={styles.title}>{title}</h3>
         <p className={styles.author}>{author}</p>
+        {status && (
+          <span className={`${styles.status} ${styles[status]}`}>
+            {t(`booksPage.status.${status}`)}
+          </span>
+        )}
+        {condition && <span className={styles.condition}>{condition}</span>}
+        <div className={styles.pills}>
+          {isForSale && (
+            <span className={styles.sale}>
+              {t('booksPage.badge.for_sale', { price })}
+            </span>
+          )}
+          {isForTrade && (
+            <span className={styles.trade}>
+              {t('booksPage.badge.for_trade')}
+              {tradePreferences && tradePreferences.length > 0 && (
+                <>
+                  {' · '}
+                  {renderTradePreferences()}
+                </>
+              )}
+            </span>
+          )}
+          {isSeeking && <span className={styles.seeking}>{t('booksPage.badge.seeking')}</span>}
+        </div>
       </div>
     </div>
   )

--- a/src/components/book/BookCard.types.ts
+++ b/src/components/book/BookCard.types.ts
@@ -2,4 +2,11 @@ export interface BookCardProps {
   title: string
   author: string
   coverUrl: string
+  condition?: string
+  status?: 'available' | 'reserved' | 'sold' | 'exchanged'
+  isForSale?: boolean
+  price?: number | null
+  isForTrade?: boolean
+  tradePreferences?: string[]
+  isSeeking?: boolean
 }

--- a/src/pages/books/BooksPage.module.scss
+++ b/src/pages/books/BooksPage.module.scss
@@ -1,0 +1,95 @@
+@import '@styles/variables';
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  padding: $spacing-2;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.searchRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+  align-items: center;
+}
+
+.search {
+  flex: 1;
+  padding: $spacing-1x5 $spacing-2;
+  border: 1px solid var(--border-color);
+  border-radius: rem(8px);
+}
+
+.chips {
+  display: flex;
+  gap: $spacing-1;
+}
+
+.chip {
+  background: var(--background-card);
+  border: 1px solid var(--border-color);
+  border-radius: rem(16px);
+  padding: 0 $spacing-2;
+  height: rem(32px);
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+}
+
+.publishButton {
+  margin-left: auto;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: rem(8px);
+  padding: $spacing-1x5 $spacing-3;
+  cursor: pointer;
+}
+
+.tabs {
+  display: flex;
+  gap: $spacing-1;
+  border-bottom: 1px solid var(--border-color);
+  overflow-x: auto;
+}
+
+.tab {
+  background: none;
+  border: none;
+  padding: $spacing-1 $spacing-2;
+  cursor: pointer;
+  font-weight: $font-weight-medium;
+  color: var(--text-secondary);
+}
+
+.tab.active {
+  color: var(--primary-color);
+  border-bottom: rem(2px) solid var(--primary-color);
+}
+
+.seeAll {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  cursor: pointer;
+}
+
+.grid {
+  display: grid;
+  gap: $spacing-2;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: $spacing-4 0;
+}

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -1,9 +1,157 @@
+import { BookCard } from '@components/book/BookCard'
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
+import React, { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import styles from './BooksPage.module.scss'
+
+interface Book {
+  id: string
+  title: string
+  author: string
+  coverUrl: string
+  condition?: string
+  status?: 'available' | 'reserved' | 'sold' | 'exchanged'
+  isForSale?: boolean
+  price?: number | null
+  isForTrade?: boolean
+  tradePreferences?: string[]
+  isSeeking?: boolean
+}
+
+const mockBooks: Book[] = [
+  {
+    id: '1',
+    title: 'Matisse en Bélgica',
+    author: 'Caros Argan',
+    coverUrl: 'https://covers.openlibrary.org/b/id/9875161-L.jpg',
+    condition: 'bueno',
+    status: 'available',
+    isForSale: true,
+    price: 15000,
+  },
+  {
+    id: '2',
+    title: '1984',
+    author: 'George Orwell',
+    coverUrl: 'https://covers.openlibrary.org/b/id/7222246-L.jpg',
+    condition: 'muy bueno',
+    status: 'reserved',
+    isForTrade: true,
+    tradePreferences: ['Dune', 'Fahrenheit 451'],
+  },
+  {
+    id: '3',
+    title: 'El cuervo',
+    author: 'Edgar Allan Poe',
+    coverUrl: 'https://covers.openlibrary.org/b/id/8231996-L.jpg',
+    condition: 'aceptable',
+    status: 'sold',
+    isForSale: true,
+    price: 12000,
+    isForTrade: true,
+    tradePreferences: ['Lovecraft', 'Drácula', 'Sherlock Holmes'],
+  },
+  {
+    id: '4',
+    title: 'El pulpo invisible',
+    author: 'A. G. Rivadera',
+    coverUrl: 'https://covers.openlibrary.org/b/id/10521241-L.jpg',
+    isSeeking: true,
+  },
+  {
+    id: '5',
+    title: 'Sapiens',
+    author: 'Yuval Noah Harari',
+    coverUrl: 'https://covers.openlibrary.org/b/id/11172236-L.jpg',
+    condition: 'nuevo',
+    status: 'exchanged',
+    isForTrade: true,
+    tradePreferences: ['Homo Deus'],
+  },
+]
 
 export const BooksPage = () => {
+  const { t } = useTranslation()
+  const [activeTab, setActiveTab] = useState<'mine' | 'trade' | 'seeking' | 'sale'>('mine')
+  const [search, setSearch] = useState('')
+
+  const tabs = useMemo(
+    () => [
+      { key: 'mine', label: t('booksPage.tabs.mine') },
+      { key: 'trade', label: t('booksPage.tabs.for_trade') },
+      { key: 'seeking', label: t('booksPage.tabs.seeking') },
+      { key: 'sale', label: t('booksPage.tabs.for_sale') },
+    ],
+    [t],
+  )
+
+  const filterByTab = (book: Book) => {
+    switch (activeTab) {
+      case 'trade':
+        return !!book.isForTrade
+      case 'seeking':
+        return !!book.isSeeking
+      case 'sale':
+        return !!book.isForSale
+      default:
+        return true
+    }
+  }
+
+  const filteredBooks = mockBooks.filter(book => {
+    const matchesSearch = `${book.title} ${book.author}`
+      .toLowerCase()
+      .includes(search.toLowerCase())
+    return matchesSearch && filterByTab(book)
+  })
+
   return (
     <BaseLayout>
-      <div className=""></div>
+      <div className={styles.wrapper}>
+        <header className={styles.header}>
+          <h1>{t('booksPage.title')}</h1>
+          <div className={styles.searchRow}>
+          <input
+            type="text"
+            className={styles.search}
+            placeholder={t('booksPage.search_placeholder') ?? ''}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <div className={styles.chips}>
+            <span className={styles.chip}>{t('booksPage.filter.near')}</span>
+            <span className={styles.chip}>{t('booksPage.filter.available')}</span>
+          </div>
+          <button className={styles.publishButton}>{t('booksPage.publish_button')}</button>
+        </div>
+      </header>
+
+      <div className={styles.tabs} role="tablist">
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            role="tab"
+            aria-selected={activeTab === tab.key}
+            className={`${styles.tab} ${activeTab === tab.key ? styles.active : ''}`}
+            onClick={() => setActiveTab(tab.key as typeof activeTab)}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <button className={styles.seeAll}>{t('booksPage.tabs.see_all')}</button>
+      </div>
+
+      {filteredBooks.length === 0 ? (
+        <div className={styles.empty}>{t(`booksPage.empty.${activeTab}`)}</div>
+      ) : (
+        <div className={styles.grid}>
+          {filteredBooks.map(book => (
+            <BookCard key={book.id} {...book} />
+          ))}
+        </div>
+      )}
+      </div>
     </BaseLayout>
   )
 }

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -23,7 +23,7 @@ const mockBooks: Book[] = [
   {
     id: '1',
     title: 'Matisse en Bélgica',
-    author: 'Caros Argan',
+    author: 'Carlos Argan',
     coverUrl: 'https://covers.openlibrary.org/b/id/9875161-L.jpg',
     condition: 'bueno',
     status: 'available',

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -73,7 +73,9 @@ const mockBooks: Book[] = [
 
 export const BooksPage = () => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState<'mine' | 'trade' | 'seeking' | 'sale'>('mine')
+  const [activeTab, setActiveTab] = useState<
+    'mine' | 'trade' | 'seeking' | 'sale'
+  >('mine')
   const [search, setSearch] = useState('')
 
   const tabs = useMemo(
@@ -83,7 +85,7 @@ export const BooksPage = () => {
       { key: 'seeking', label: t('booksPage.tabs.seeking') },
       { key: 'sale', label: t('booksPage.tabs.for_sale') },
     ],
-    [t],
+    [t]
   )
 
   const filterByTab = (book: Book) => {
@@ -99,7 +101,7 @@ export const BooksPage = () => {
     }
   }
 
-  const filteredBooks = mockBooks.filter(book => {
+  const filteredBooks = mockBooks.filter((book) => {
     const matchesSearch = `${book.title} ${book.author}`
       .toLowerCase()
       .includes(search.toLowerCase())
@@ -112,45 +114,53 @@ export const BooksPage = () => {
         <header className={styles.header}>
           <h1>{t('booksPage.title')}</h1>
           <div className={styles.searchRow}>
-          <input
-            type="text"
-            className={styles.search}
-            placeholder={t('booksPage.search_placeholder') ?? ''}
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
-          <div className={styles.chips}>
-            <span className={styles.chip}>{t('booksPage.filter.near')}</span>
-            <span className={styles.chip}>{t('booksPage.filter.available')}</span>
+            <input
+              type="text"
+              className={styles.search}
+              placeholder={t('booksPage.search_placeholder') ?? ''}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <div className={styles.chips}>
+              <span className={styles.chip}>{t('booksPage.filter.near')}</span>
+              <span className={styles.chip}>
+                {t('booksPage.filter.available')}
+              </span>
+            </div>
+            <button className={styles.publishButton}>
+              {t('booksPage.publish_button')}
+            </button>
           </div>
-          <button className={styles.publishButton}>{t('booksPage.publish_button')}</button>
-        </div>
-      </header>
+        </header>
 
-      <div className={styles.tabs} role="tablist">
-        {tabs.map(tab => (
-          <button
-            key={tab.key}
-            role="tab"
-            aria-selected={activeTab === tab.key}
-            className={`${styles.tab} ${activeTab === tab.key ? styles.active : ''}`}
-            onClick={() => setActiveTab(tab.key as typeof activeTab)}
-          >
-            {tab.label}
-          </button>
-        ))}
-        <button className={styles.seeAll}>{t('booksPage.tabs.see_all')}</button>
-      </div>
-
-      {filteredBooks.length === 0 ? (
-        <div className={styles.empty}>{t(`booksPage.empty.${activeTab}`)}</div>
-      ) : (
-        <div className={styles.grid}>
-          {filteredBooks.map(book => (
-            <BookCard key={book.id} {...book} />
+        <div className={styles.tabs} role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              className={`${styles.tab} ${activeTab === tab.key ? styles.active : ''}`}
+              onClick={() => setActiveTab(tab.key as typeof activeTab)}
+            >
+              {tab.label}
+            </button>
           ))}
+          <button className={styles.seeAll}>
+            {t('booksPage.tabs.see_all')}
+          </button>
         </div>
-      )}
+
+        {filteredBooks.length === 0 ? (
+          <div className={styles.empty}>
+            {t(`booksPage.empty.${activeTab}`)}
+          </div>
+        ) : (
+          <div className={styles.grid}>
+            {filteredBooks.map((book) => (
+              <BookCard key={book.id} {...book} />
+            ))}
+          </div>
+        )}
       </div>
     </BaseLayout>
   )


### PR DESCRIPTION
## Summary
- build Explore Books page with search bar, tab filters and mock data
- expand BookCard to show status, condition and sale/trade/seeking badges
- add i18n strings for books page labels and statuses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4037aa7fc832e93ce32b7276b123b