### PR TITLE
feat: persist theme and language preferences

### DIFF
--- a/src/assets/i18n/i18n.ts
+++ b/src/assets/i18n/i18n.ts
@@ -4,6 +4,9 @@ import { initReactI18next } from 'react-i18next'
 import enTranslations from './locales/en/common.json'
 import esTranslations from './locales/es/common.json'
 
+const storedLanguage =
+  typeof window !== 'undefined' ? localStorage.getItem('language') : null
+
 declare module 'react-i18next' {
   interface Resources {
     translation: typeof esTranslations
@@ -15,11 +18,17 @@ i18n.use(initReactI18next).init({
     en: { translation: enTranslations },
     es: { translation: esTranslations },
   },
-  lng: 'es',
+  lng: storedLanguage || 'es',
   fallbackLng: 'es',
   interpolation: {
     escapeValue: false,
   },
+})
+
+i18n.on('languageChanged', (lng) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('language', lng)
+  }
 })
 
 export default i18n

--- a/src/contexts/theme/ThemeContext.tsx
+++ b/src/contexts/theme/ThemeContext.tsx
@@ -7,10 +7,19 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
 )
 
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const storedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null
+      if (storedTheme) return storedTheme
+    }
+    return 'light'
+  })
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme)
+    }
   }, [theme])
 
   const toggleTheme = () => {

--- a/src/contexts/theme/ThemeContext.tsx
+++ b/src/contexts/theme/ThemeContext.tsx
@@ -9,7 +9,10 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window !== 'undefined') {
-      const storedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null
+      const storedTheme = localStorage.getItem('theme') as
+        | 'light'
+        | 'dark'
+        | null
       if (storedTheme) return storedTheme
     }
     return 'light'

--- a/tests/hooks/theme/useTheme.test.ts
+++ b/tests/hooks/theme/useTheme.test.ts
@@ -8,6 +8,10 @@ import {
 import { useTheme } from '../../../src/hooks/theme/useTheme'
 
 describe('useTheme', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
   test('returns context when used within ThemeProvider', () => {
     const { result } = renderHook(() => useTheme(), {
       wrapper: ThemeProvider,
@@ -36,5 +40,21 @@ describe('useTheme', () => {
     expect(() => renderHook(() => useThemeFromContext())).toThrow(
       'useTheme must be used within a ThemeProvider'
     )
+  })
+
+  test('persists theme to localStorage', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    act(() => result.current.toggleTheme())
+    expect(window.localStorage.getItem('theme')).toBe('dark')
+  })
+
+  test('initializes theme from localStorage', () => {
+    window.localStorage.setItem('theme', 'dark')
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    expect(result.current.theme).toBe('dark')
   })
 })

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -10,4 +10,3 @@ describe('i18n language persistence', () => {
     expect(window.localStorage.getItem('language')).toBe('en')
   })
 })
-

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,0 +1,13 @@
+import i18n from '../../src/assets/i18n/i18n'
+
+describe('i18n language persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('saves selected language to localStorage', async () => {
+    await i18n.changeLanguage('en')
+    expect(window.localStorage.getItem('language')).toBe('en')
+  })
+})
+


### PR DESCRIPTION
## Summary
- persist selected theme in localStorage and load it on startup
- remember chosen language and restore it on reload
- test theme and language persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a409667150832e84e622333d50f8b3