### PR TITLE
refactor: migrate interfaces to type aliases

### DIFF
--- a/src/api/auth/login.types.ts
+++ b/src/api/auth/login.types.ts
@@ -1,9 +1,13 @@
-export interface LoginRequest {
+/**
+ * Tipos para el proceso de inicio de sesión.
+ * TODO: considerar soporte para autenticación multifactor.
+ */
+export type LoginRequest = {
   email: string
   password: string
 }
 
-export interface LoginResponse {
+export type LoginResponse = {
   token: string
   user: {
     id: string
@@ -16,7 +20,7 @@ export interface LoginResponse {
   message: string
 }
 
-export interface LoginError {
+export type LoginError = {
   error: 'InvalidCredentials' | 'AccountLocked' | 'MissingFields'
   message: string
   remainingAttempts?: number

--- a/src/api/books/books.types.ts
+++ b/src/api/books/books.types.ts
@@ -1,4 +1,8 @@
-export interface Book {
+/**
+ * Representa un libro obtenido desde la API.
+ * TODO: extender con más metadatos del libro.
+ */
+export type Book = {
   title: string
   author: string
   coverUrl: string

--- a/src/api/contactForm/contactForm.types.ts
+++ b/src/api/contactForm/contactForm.types.ts
@@ -1,9 +1,13 @@
-export interface ContactFormData {
+/**
+ * Tipos relacionados con el formulario de contacto.
+ * TODO: agregar validaciones más estrictas para los campos.
+ */
+export type ContactFormData = {
   name: string
   email: string
   message: string
 }
 
-export interface ContactFormResponse {
+export type ContactFormResponse = {
   message: string
 }

--- a/src/assets/i18n/i18n.ts
+++ b/src/assets/i18n/i18n.ts
@@ -5,11 +5,13 @@ import enTranslations from './locales/en/common.json'
 import esTranslations from './locales/es/common.json'
 
 declare module 'react-i18next' {
-  interface Resources {
+  // TODO: verificar si es necesario declarar recursos adicionales
+  type Resources = {
     translation: typeof esTranslations
   }
 }
 
+// Configuración de internacionalización
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: enTranslations },

--- a/src/components/form/base/FormBase.types.ts
+++ b/src/components/form/base/FormBase.types.ts
@@ -1,3 +1,7 @@
+/**
+ * Tipos base para formularios reutilizables.
+ * TODO: admitir más tipos de campos y validaciones.
+ */
 export type InputType = 'text' | 'email' | 'textarea'
 
 export type FormField = {
@@ -9,13 +13,13 @@ export type FormField = {
   placeholder?: string
 }
 
-export interface FormBaseProps {
+export type FormBaseProps = {
   fields: FormField[]
   onSubmit: (formData: Record<string, string>) => void
   submitLabel?: string
   isSubmitting?: boolean
 }
 
-export interface FormBaseRef {
+export type FormBaseRef = {
   resetForm: () => void
 }

--- a/src/components/layout/BaseLayout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout/BaseLayout.tsx
@@ -1,14 +1,14 @@
-import { ReactNode } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { Sidebar } from '../../sidebar/Sidebar'
 
 import styles from './BaseLayout.module.scss'
+import type { BaseLayoutProps } from './BaseLayout.types'
 
-interface BaseLayoutProps {
-  children?: ReactNode
-}
-
+/**
+ * Layout principal de la aplicación.
+ * TODO: revisar accesibilidad del contenedor principal.
+ */
 export const BaseLayout = ({ children }: BaseLayoutProps) => {
   return (
     <div className={styles.baseLayout}>

--- a/src/components/layout/BaseLayout/BaseLayout.types.ts
+++ b/src/components/layout/BaseLayout/BaseLayout.types.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Propiedades para el layout base.
+ * TODO: considerar opciones para personalizar el Sidebar.
+ */
+export type BaseLayoutProps = {
+  children?: ReactNode
+}

--- a/src/contexts/auth/AuthContext.types.ts
+++ b/src/contexts/auth/AuthContext.types.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from 'react'
 
-export interface AuthUser {
+/**
+ * Datos básicos del usuario autenticado.
+ * TODO: incluir más información del perfil cuando esté disponible.
+ */
+export type AuthUser = {
   id: string
   email: string
 }

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -4,21 +4,9 @@ import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import styles from './BooksPage.module.scss'
+import type { Book } from './BooksPage.types'
 
-interface Book {
-  id: string
-  title: string
-  author: string
-  coverUrl: string
-  condition?: string
-  status?: 'available' | 'reserved' | 'sold' | 'exchanged'
-  isForSale?: boolean
-  price?: number | null
-  isForTrade?: boolean
-  tradePreferences?: string[]
-  isSeeking?: boolean
-}
-
+// TODO: reemplazar este arreglo por datos provenientes del backend
 const mockBooks: Book[] = [
   {
     id: '1',
@@ -88,6 +76,7 @@ export const BooksPage = () => {
     [t]
   )
 
+  // TODO: mover este filtro a un hook reutilizable si se complica
   const filterByTab = (book: Book) => {
     switch (activeTab) {
       case 'trade':

--- a/src/pages/books/BooksPage.types.ts
+++ b/src/pages/books/BooksPage.types.ts
@@ -1,8 +1,9 @@
 /**
- * Propiedades para el componente BookCard.
- * TODO: unificar los estados en un enum reutilizable.
+ * Representa un libro dentro de la aplicación.
+ * TODO: mover los estados y condiciones a tipos compartidos.
  */
-export type BookCardProps = {
+export type Book = {
+  id: string
   title: string
   author: string
   coverUrl: string

--- a/src/shared/types/global.d.ts
+++ b/src/shared/types/global.d.ts
@@ -17,7 +17,8 @@ declare module '*.svg' {
   export default src
 }
 
-// Public envs exposed by Rsbuild (client-side)
+// Variables de entorno públicas expuestas por Rsbuild (lado del cliente)
+// TODO: revisar otras variables públicas necesarias y evaluar si se pueden usar types
 declare interface ImportMetaEnv {
   readonly PUBLIC_MSW_FORCE_AUTH?: 'auto' | 'logged-in' | 'logged-out'
   readonly PUBLIC_API_BASE_URL?: string


### PR DESCRIPTION
## Summary
- replace legacy interfaces with type aliases across modules
- move component and page types to dedicated files
- translate comments to Spanish and document pending improvements

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40900de98832e9d1cc73954b1aa6b