### PR TITLE
feat: add responsive mobile sidebar

### DIFF
--- a/src/components/sidebar/Sidebar.module.scss
+++ b/src/components/sidebar/Sidebar.module.scss
@@ -16,14 +16,23 @@
     width: $expanded-width;
   }
 
+  &.open {
+    width: $expanded-width;
+  }
+
   @media (max-width: $breakpoint-tablet) {
-    width: $collapsed-width;
-    bottom: 0;
-    height: auto;
-    top: auto;
+    transform: translateX(-100%);
+    width: $expanded-width;
+    transition: transform $transition-speed ease;
+    bottom: auto;
+    height: 100vh;
 
     &:hover {
-      width: $collapsed-width;
+      width: $expanded-width;
+    }
+
+    &.open {
+      transform: translateX(0);
     }
   }
 }
@@ -63,6 +72,43 @@
   margin-top: auto;
 }
 
+/* === Mobile Toggle Button === */
+.mobileToggle {
+  display: none;
+  position: fixed;
+  top: $spacing-4;
+  left: $spacing-4;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: $z-index-fixed;
+  flex-direction: column;
+  justify-content: space-between;
+  width: rem(24px);
+  height: rem(18px);
+
+  span {
+    display: block;
+    width: 100%;
+    height: rem(2px);
+    background: var(--text-primary);
+  }
+
+  @media (max-width: $breakpoint-tablet) {
+    display: flex;
+  }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgb(0 0 0 / 30%);
+  z-index: 999;
+}
+
 /* === Icons and shared Label === */
 .icon {
   font-size: 1.5rem;
@@ -83,7 +129,8 @@
   flex-grow: 0;
 }
 
-.sidebar:hover .label {
+.sidebar:hover .label,
+.sidebar.open .label {
   opacity: 1;
   transform: translateX(0);
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -15,7 +15,7 @@ import { HOME_URLS } from '@/constants/constants'
 import styles from './Sidebar.module.scss'
 
 export const Sidebar = () => {
-  const [isHovered, setIsHovered] = useState(false)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
   const { t } = useTranslation()
 
   const navItems: NavItem[] = [
@@ -41,35 +41,47 @@ export const Sidebar = () => {
     },
   ]
 
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev)
+  const closeMenu = () => setIsMenuOpen(false)
+
   return (
-    <nav
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      className={`${styles.sidebar} ${isHovered ? styles.expanded : ''}`}
-    >
-      <div className={styles.navItems}>
-        {navItems.map((item) => {
-          const IconComponent = item.icon
-          return (
-            <NavLink
-              key={item.path}
-              to={item.path}
-              className={({ isActive }) =>
-                `${styles.navLink} ${isActive ? styles.active : ''}`
-              }
-            >
-              <IconComponent className={styles.icon} />
-              <span className={styles.label}>{item.label}</span>
-            </NavLink>
-          )
-        })}
-      </div>
-      {/* Footer section of Sidebar */}
-      <div className={styles.footer}>
-        <SidebarLanguageSwitcher />
-        <SidebarThemeButton />
-        <SidebarLoginButton />
-      </div>
-    </nav>
+    <>
+      <button
+        className={styles.mobileToggle}
+        onClick={toggleMenu}
+        aria-label="Toggle navigation"
+      >
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav className={`${styles.sidebar} ${isMenuOpen ? styles.open : ''}`}>
+        <div className={styles.navItems}>
+          {navItems.map((item) => {
+            const IconComponent = item.icon
+            return (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                onClick={closeMenu}
+                className={({ isActive }) =>
+                  `${styles.navLink} ${isActive ? styles.active : ''}`
+                }
+              >
+                <IconComponent className={styles.icon} />
+                <span className={styles.label}>{item.label}</span>
+              </NavLink>
+            )
+          })}
+        </div>
+        {/* Footer section of Sidebar */}
+        <div className={styles.footer}>
+          <SidebarLanguageSwitcher />
+          <SidebarThemeButton />
+          <SidebarLoginButton />
+        </div>
+      </nav>
+      {isMenuOpen && <div className={styles.overlay} onClick={closeMenu} />}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add hamburger toggle for sidebar on small screens
- slide-in sidebar with overlay for mobile

## Testing
- `npm run lint`
- `npm run stylelint`
- `npm run format`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40a30906c832e975d256d50b8eb1f