### PR TITLE
refactor: differentiate API book type

### DIFF
--- a/src/api/books/books.service.ts
+++ b/src/api/books/books.service.ts
@@ -1,9 +1,9 @@
 import { apiClient } from '@/api/axios'
 import { RELATIVE_API_ROUTES } from '@/api/routes'
 
-import { Book } from './books.types'
+import { ApiBook } from './books.types'
 
-export const fetchBooks = async (): Promise<Book[]> => {
-  const response = await apiClient.get<Book[]>(RELATIVE_API_ROUTES.BOOKS.LIST)
+export const fetchBooks = async (): Promise<ApiBook[]> => {
+  const response = await apiClient.get<ApiBook[]>(RELATIVE_API_ROUTES.BOOKS.LIST)
   return response.data
 }

--- a/src/api/books/books.types.ts
+++ b/src/api/books/books.types.ts
@@ -1,8 +1,8 @@
 /**
- * Representa un libro obtenido desde la API.
+ * Representa un libro tal como se recibe desde la API.
  * TODO: extender con más metadatos del libro.
  */
-export type Book = {
+export type ApiBook = {
   title: string
   author: string
   coverUrl: string


### PR DESCRIPTION
## Summary
- rename API book type to ApiBook to avoid confusion with app Book type
- update book service to use ApiBook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40ce52a30832e87f7844f7504b60d