### PR TITLE
fix: improve language selector translations

### DIFF
--- a/src/assets/i18n/locales/en/common.json
+++ b/src/assets/i18n/locales/en/common.json
@@ -66,9 +66,14 @@
     "community_logged_in_cta": "Go to community"
   },
   "activity": {
-    "added": "Ofreciste",
-    "exchanged": "Intercambiaste",
-    "cover_alt": "Portada de {{title}}"
+    "added": "You added",
+    "exchanged": "You exchanged",
+    "cover_alt": "Cover of {{title}}"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "es": "Spanish"
   },
   "booksPage": {
     "title": "Explore books",

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -66,9 +66,14 @@
     "community_logged_in_cta": "Ir a la comunidad"
   },
   "activity": {
-    "added": "You added",
-    "exchanged": "You exchanged",
-    "cover_alt": "Cover of {{title}}"
+    "added": "Ofreciste",
+    "exchanged": "Intercambiaste",
+    "cover_alt": "Portada de {{title}}"
+  },
+  "language": {
+    "label": "Idioma",
+    "en": "Inglés",
+    "es": "Español"
   },
   "booksPage": {
     "title": "Explorar libros",

--- a/src/components/sidebar/buttons/SidebarLanguageSwitcher.tsx
+++ b/src/components/sidebar/buttons/SidebarLanguageSwitcher.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as Globe } from '@/assets/icons/globe.svg'
 import styles from '../Sidebar.module.scss'
 
 export const SidebarLanguageSwitcher = () => {
-  const { i18n } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [open, setOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -33,13 +33,17 @@ export const SidebarLanguageSwitcher = () => {
     <div className={styles.languageButtonWrapper} ref={dropdownRef}>
       <button onClick={toggleDropdown} className={styles.languageButton}>
         <Globe className={styles.icon} />
-        <span className={styles.label}>Idioma</span>
+        <span className={styles.label}>{t('language.label')}</span>
       </button>
 
       {open && (
         <div className={styles.dropdown}>
-          <button onClick={() => changeLanguage('es')}>Español</button>
-          <button onClick={() => changeLanguage('en')}>English</button>
+          <button onClick={() => changeLanguage('es')}>
+            {t('language.es')}
+          </button>
+          <button onClick={() => changeLanguage('en')}>
+            {t('language.en')}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- translate sidebar language switcher
- correct swapped activity translations in locales

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a40f15f4cc832eb9f6cab8dab7fdc6