### PR TITLE
chore: ensure consistent Prettier configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5",
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jsdom": "^26.1.0",
     "msw": "^2.10.4",
-    "prettier": "^3.6.2",
+    "prettier": "3.6.2",
     "sass": "^1.89.2",
     "sass-loader": "^16.0.5",
     "style-loader": "^4.0.0",

--- a/src/api/books/books.service.ts
+++ b/src/api/books/books.service.ts
@@ -4,6 +4,8 @@ import { RELATIVE_API_ROUTES } from '@/api/routes'
 import { ApiBook } from './books.types'
 
 export const fetchBooks = async (): Promise<ApiBook[]> => {
-  const response = await apiClient.get<ApiBook[]>(RELATIVE_API_ROUTES.BOOKS.LIST)
+  const response = await apiClient.get<ApiBook[]>(
+    RELATIVE_API_ROUTES.BOOKS.LIST
+  )
   return response.data
 }


### PR DESCRIPTION
## Summary
- format books service to satisfy Prettier
- pin Prettier version and enforce LF line endings for consistent formatting

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41155d6ac832eae5b5f8903d4f682