### PR TITLE
feat: add user registration flow

### DIFF
--- a/mocks/handlers/auth/fixtures/register.error.json
+++ b/mocks/handlers/auth/fixtures/register.error.json
@@ -1,0 +1,4 @@
+{
+  "error": "EmailExists",
+  "message": "auth.errors.email_exists"
+}

--- a/mocks/handlers/auth/fixtures/register.success.json
+++ b/mocks/handlers/auth/fixtures/register.success.json
@@ -1,0 +1,9 @@
+{
+  "token": "fake-register-token",
+  "user": {
+    "id": "2",
+    "email": "new@entrelibros.com",
+    "role": "user"
+  },
+  "message": "auth.success.register"
+}

--- a/mocks/handlers/auth/register.handler.ts
+++ b/mocks/handlers/auth/register.handler.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw'
+
+import { RegisterRequest } from '@/api/auth/register.types'
+import { RELATIVE_API_ROUTES } from '@/api/routes'
+
+import { DEFAULT_EMAIL } from '../../constants/constants'
+
+import errorResponse from './fixtures/register.error.json'
+import successResponse from './fixtures/register.success.json'
+import { setLoggedInState } from './me.handler'
+
+export const registerHandler = http.post(
+  RELATIVE_API_ROUTES.AUTH.REGISTER,
+  async ({ request }) => {
+    const body = (await request.json()) as RegisterRequest
+    const { email } = body
+
+    if (email === DEFAULT_EMAIL) {
+      return HttpResponse.json(errorResponse, { status: 409 })
+    }
+
+    setLoggedInState(true)
+    return HttpResponse.json(successResponse, { status: 201 })
+  }
+)

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,11 +1,13 @@
 import { loginHandler } from './auth/login.handler'
 import { logoutHandler } from './auth/logout.handler'
 import { authStateHandler, meHandler } from './auth/me.handler'
+import { registerHandler } from './auth/register.handler'
 import { booksHandler } from './books/books.handler'
 import { contactFormHandler } from './contactForm/contactForm.handler'
 
 export const handlers = [
   loginHandler,
+  registerHandler,
   logoutHandler,
   authStateHandler,
   meHandler,

--- a/src/api/auth/register.service.ts
+++ b/src/api/auth/register.service.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/api/axios'
+import { RELATIVE_API_ROUTES } from '@/api/routes'
+
+import { RegisterRequest, RegisterResponse } from './register.types'
+
+export const register = async (
+  data: RegisterRequest
+): Promise<RegisterResponse> => {
+  const response = await apiClient.post<RegisterResponse>(
+    RELATIVE_API_ROUTES.AUTH.REGISTER,
+    data
+  )
+  return response.data
+}

--- a/src/api/auth/register.types.ts
+++ b/src/api/auth/register.types.ts
@@ -1,0 +1,24 @@
+/**
+ * Types for user registration.
+ */
+export type RegisterRequest = {
+  name: string
+  email: string
+  password: string
+}
+
+export type RegisterResponse = {
+  token: string
+  user: {
+    id: string
+    email: string
+    role: 'user' | 'admin'
+    name?: string
+  }
+  message: string
+}
+
+export type RegisterError = {
+  error: 'EmailExists' | 'MissingFields'
+  message: string
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4,6 +4,7 @@ export const RELATIVE_API_ROUTES = {
     LOGOUT: `/auth/logout`,
     PROFILE: `/auth/profile`,
     ME: `/auth/me`,
+    REGISTER: `/auth/register`,
   },
   CONTACT_FORM: {
     SUBMIT: `/contact/submit`,

--- a/src/assets/i18n/locales/en/common.json
+++ b/src/assets/i18n/locales/en/common.json
@@ -4,14 +4,21 @@
   "email": "Email",
   "password": "Password",
   "login": "Login",
+  "register": "Sign up",
+  "name": "Name",
+  "confirm_password": "Confirm password",
+  "no_account": "Don't have an account?",
+  "have_account": "Already have an account?",
   "authenticating": "Authenticating...",
   "auth": {
     "errors": {
       "invalid_credentials": "Invalid email or password.",
+      "email_exists": "Email is already registered.",
       "unknown": "An unexpected error occurred."
     },
     "success": {
-      "login": "Login successful!"
+      "login": "Login successful!",
+      "register": "Registration successful!"
     }
   },
   "theme": {

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -4,14 +4,21 @@
   "email": "Correo electrónico",
   "password": "Contraseña",
   "login": "Iniciar sesión",
+  "register": "Registrarse",
+  "name": "Nombre",
+  "confirm_password": "Confirmar contraseña",
+  "no_account": "¿No tenés cuenta?",
+  "have_account": "¿Ya tenés cuenta?",
   "authenticating": "Autenticando...",
   "auth": {
     "errors": {
       "invalid_credentials": "Correo electrónico o contraseña incorrectos.",
+      "email_exists": "El correo ya está registrado.",
       "unknown": "Ocurrió un error inesperado."
     },
     "success": {
-      "login": "¡Inicio de sesión exitoso!"
+      "login": "¡Inicio de sesión exitoso!",
+      "register": "¡Registro exitoso!"
     }
   },
   "theme": {

--- a/src/components/register/RegisterForm.module.scss
+++ b/src/components/register/RegisterForm.module.scss
@@ -3,7 +3,8 @@
 .registerForm {
   max-width: 440px;
   padding: 2rem;
-  transition: background-color $transition-duration-normal $transition-timing-function;
+  transition: background-color $transition-duration-normal
+    $transition-timing-function;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/src/components/register/RegisterForm.module.scss
+++ b/src/components/register/RegisterForm.module.scss
@@ -1,7 +1,7 @@
 @import '@styles/variables';
 
 .registerForm {
-  max-width: 440px;
+  max-width: rem(440px);
   padding: 2rem;
   transition: background-color $transition-duration-normal
     $transition-timing-function;
@@ -38,7 +38,7 @@
 .input {
   padding: 1rem;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: rem(8px);
   background: var(--background-primary);
   color: var(--text-primary);
 

--- a/src/components/register/RegisterForm.module.scss
+++ b/src/components/register/RegisterForm.module.scss
@@ -1,0 +1,89 @@
+@import '@styles/variables';
+
+.registerForm {
+  max-width: 440px;
+  padding: 2rem;
+  transition: background-color $transition-duration-normal $transition-timing-function;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.input {
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--background-primary);
+  color: var(--text-primary);
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgb(var(--primary-rgb), 0.1);
+  }
+}
+
+.errorMessage {
+  color: var(--error-color, #dc2626);
+  font-size: 0.875rem;
+}
+
+.submitButton {
+  width: 100%;
+  padding: 1rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--primary-color);
+  color: white;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: var(--primary-dark);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+}
+
+.loginLink {
+  text-align: center;
+  margin-top: 1rem;
+
+  a {
+    color: var(--primary-color);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -7,14 +7,7 @@ import { HOME_URLS } from '@/constants/constants'
 import { useRegister } from '@/hooks/api/useRegister'
 
 import styles from './RegisterForm.module.scss'
-import { RegisterFormProps } from './RegisterForm.types'
-
-type FormValues = {
-  name: string
-  email: string
-  password: string
-  confirmPassword: string
-}
+import { FormValues, RegisterFormProps } from './RegisterForm.types'
 
 export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
   const { t } = useTranslation()

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { showToast } from '@/components/ui/toaster/Toaster'
 import { HOME_URLS } from '@/constants/constants'
@@ -29,9 +29,8 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
 
   const getErrorMessage = (error: unknown) => {
     const err = error as { response?: { data?: { message?: string } } }
-    const message = err.response?.data?.message
-    const translated = t(message)
-    return translated === message ? t('auth.errors.unknown') : translated
+    const message = err.response?.data?.message || 'auth.errors.unknown'
+    return t(message)
   }
 
   const onSubmitForm = (data: FormValues) => {
@@ -67,7 +66,9 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
           {...register('name', { required: true })}
         />
         {errors.name && (
-          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+          <span className={styles.errorMessage}>
+            {t('form.errors.required')}
+          </span>
         )}
         <input
           type="email"
@@ -76,7 +77,9 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
           {...register('email', { required: true })}
         />
         {errors.email && (
-          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+          <span className={styles.errorMessage}>
+            {t('form.errors.required')}
+          </span>
         )}
         <input
           type="password"
@@ -85,7 +88,9 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
           {...register('password', { required: true, minLength: 6 })}
         />
         {errors.password && (
-          <span className={styles.errorMessage}>{t('form.errors.min_length', { count: 6 })}</span>
+          <span className={styles.errorMessage}>
+            {t('form.errors.min_length', { count: 6 })}
+          </span>
         )}
         <input
           type="password"
@@ -96,7 +101,9 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
           })}
         />
         {errors.confirmPassword && (
-          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+          <span className={styles.errorMessage}>
+            {t('form.errors.required')}
+          </span>
         )}
       </div>
 
@@ -109,8 +116,7 @@ export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
       </button>
 
       <p className={styles.loginLink}>
-        {t('have_account')}{' '}
-        <Link to={`/${HOME_URLS.LOGIN}`}>{t('login')}</Link>
+        {t('have_account')} <Link to={`/${HOME_URLS.LOGIN}`}>{t('login')}</Link>
       </p>
     </form>
   )

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -1,0 +1,117 @@
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { useNavigate, Link } from 'react-router-dom'
+
+import { showToast } from '@/components/ui/toaster/Toaster'
+import { HOME_URLS } from '@/constants/constants'
+import { useRegister } from '@/hooks/api/useRegister'
+
+import styles from './RegisterForm.module.scss'
+import { RegisterFormProps } from './RegisterForm.types'
+
+type FormValues = {
+  name: string
+  email: string
+  password: string
+  confirmPassword: string
+}
+
+export const RegisterForm = ({ onSubmit }: RegisterFormProps) => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { mutate: doRegister, isPending } = useRegister()
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>()
+
+  const getErrorMessage = (error: unknown) => {
+    const err = error as { response?: { data?: { message?: string } } }
+    const message = err.response?.data?.message
+    const translated = t(message)
+    return translated === message ? t('auth.errors.unknown') : translated
+  }
+
+  const onSubmitForm = (data: FormValues) => {
+    doRegister(
+      { name: data.name, email: data.email, password: data.password },
+      {
+        onSuccess: (response) => {
+          showToast(t('auth.success.register'), 'success')
+          onSubmit?.(response)
+          navigate(`/${HOME_URLS.LOGIN}`)
+        },
+        onError: (error: unknown) => {
+          showToast(getErrorMessage(error), 'error')
+        },
+      }
+    )
+  }
+
+  const password = watch('password')
+
+  return (
+    <form className={styles.registerForm} onSubmit={handleSubmit(onSubmitForm)}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>{t('welcome')}</h2>
+        <p className={styles.subtitle}>{t('login_subtitle')}</p>
+      </div>
+
+      <div className={styles.formGroup}>
+        <input
+          type="text"
+          placeholder={t('name')}
+          className={styles.input}
+          {...register('name', { required: true })}
+        />
+        {errors.name && (
+          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+        )}
+        <input
+          type="email"
+          placeholder={t('email')}
+          className={styles.input}
+          {...register('email', { required: true })}
+        />
+        {errors.email && (
+          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+        )}
+        <input
+          type="password"
+          placeholder={t('password')}
+          className={styles.input}
+          {...register('password', { required: true, minLength: 6 })}
+        />
+        {errors.password && (
+          <span className={styles.errorMessage}>{t('form.errors.min_length', { count: 6 })}</span>
+        )}
+        <input
+          type="password"
+          placeholder={t('confirm_password')}
+          className={styles.input}
+          {...register('confirmPassword', {
+            validate: (value) => value === password,
+          })}
+        />
+        {errors.confirmPassword && (
+          <span className={styles.errorMessage}>{t('form.errors.required')}</span>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        className={styles.submitButton}
+        disabled={isPending}
+      >
+        {isPending ? t('authenticating') : t('register')}
+      </button>
+
+      <p className={styles.loginLink}>
+        {t('have_account')}{' '}
+        <Link to={`/${HOME_URLS.LOGIN}`}>{t('login')}</Link>
+      </p>
+    </form>
+  )
+}

--- a/src/components/register/RegisterForm.types.ts
+++ b/src/components/register/RegisterForm.types.ts
@@ -1,0 +1,3 @@
+export type RegisterFormProps = {
+  onSubmit?: (data: unknown) => void
+}

--- a/src/components/register/RegisterForm.types.ts
+++ b/src/components/register/RegisterForm.types.ts
@@ -1,3 +1,10 @@
 export type RegisterFormProps = {
   onSubmit?: (data: unknown) => void
 }
+
+export type FormValues = {
+  name: string
+  email: string
+  password: string
+  confirmPassword: string
+}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -8,4 +8,5 @@ export const HOME_URLS = {
   COMMUNITY: 'community',
   CONTACT: 'contact',
   LOGIN: 'login',
+  REGISTER: 'register',
 } as const

--- a/src/hooks/api/useRegister.ts
+++ b/src/hooks/api/useRegister.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { register } from '@/api/auth/register.service'
+import { AuthQueryKeys } from '@/constants/constants'
+
+export const useRegister = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: register,
+    onSuccess: (data) => {
+      queryClient.setQueryData([AuthQueryKeys.AUTH], data.user)
+    },
+    onError: () => {
+      queryClient.removeQueries({ queryKey: [AuthQueryKeys.AUTH] })
+    },
+  })
+}

--- a/src/pages/login/LoginPage.module.scss
+++ b/src/pages/login/LoginPage.module.scss
@@ -18,7 +18,7 @@
 .welcomeSection {
   text-align: center;
   margin-bottom: 3rem;
-  max-width: 600px;
+  max-width: rem(600px);
 
   h1 {
     font-size: 2.5rem;
@@ -47,7 +47,7 @@
   max-width: rem(440px);
   margin: 0 auto;
   padding: 0 1rem;
-  transform: translateY(-30%);
+  transform: translateY(-20%);
 }
 
 .registerLink {

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,15 +1,24 @@
 import { Header } from '@components/layout/header/Header'
 import { LoginForm } from '@components/login/LoginForm'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { HOME_URLS } from '@/constants/constants'
 
 import styles from './LoginPage.module.scss'
 
 const LoginPage = () => {
+  const { t } = useTranslation()
   return (
     <div className={styles.homeContainer}>
       <Header></Header>
       <main className={styles.mainContent}>
         <div className={styles.authSection}>
           <LoginForm onSubmit={() => {}} />
+          <div className={styles.registerLink}>
+            {t('no_account')}{' '}
+            <Link to={`/${HOME_URLS.REGISTER}`}>{t('register')}</Link>
+          </div>
         </div>
       </main>
     </div>

--- a/src/pages/register/RegisterPage.module.scss
+++ b/src/pages/register/RegisterPage.module.scss
@@ -49,17 +49,3 @@
   padding: 0 1rem;
   transform: translateY(-30%);
 }
-
-.registerLink {
-  margin-top: 1rem;
-  text-align: center;
-
-  a {
-    color: var(--primary-color);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}

--- a/src/pages/register/RegisterPage.module.scss
+++ b/src/pages/register/RegisterPage.module.scss
@@ -18,7 +18,7 @@
 .welcomeSection {
   text-align: center;
   margin-bottom: 3rem;
-  max-width: 600px;
+  max-width: rem(600px);
 
   h1 {
     font-size: 2.5rem;
@@ -47,5 +47,4 @@
   max-width: rem(440px);
   margin: 0 auto;
   padding: 0 1rem;
-  transform: translateY(-30%);
 }

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -1,0 +1,19 @@
+import { Header } from '@components/layout/header/Header'
+import { RegisterForm } from '@components/register/RegisterForm'
+
+import styles from './RegisterPage.module.scss'
+
+const RegisterPage = () => {
+  return (
+    <div className={styles.homeContainer}>
+      <Header></Header>
+      <main className={styles.mainContent}>
+        <div className={styles.authSection}>
+          <RegisterForm onSubmit={() => {}} />
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default RegisterPage

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import { CommunityPage } from '@/pages/community/CommunityPage'
 import { ContactPage } from '@/pages/contact/ContactPage'
 import { HomePage } from '@/pages/home/HomePage'
 import LoginPage from '@/pages/login/LoginPage'
+import RegisterPage from '@/pages/register/RegisterPage'
 
 import NotFound from '../pages/not_found/NotFound'
 
@@ -16,6 +17,7 @@ const AppRoutes = () => {
     <BrowserRouter basename="/">
       <Routes>
         <Route path={`/${HOME_URLS.LOGIN}`} element={<LoginPage />} />
+        <Route path={`/${HOME_URLS.REGISTER}`} element={<RegisterPage />} />
         <Route path="*" element={<NotFound />} />
         <Route element={<BaseLayout />}>
           <Route path="/" element={<HomePage />} />

--- a/tests/api/auth/register.service.test.ts
+++ b/tests/api/auth/register.service.test.ts
@@ -1,0 +1,31 @@
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { DEFAULT_EMAIL } from '../../../mocks/constants/constants'
+import { registerHandler } from '../../../mocks/handlers/auth/register.handler'
+import { register } from '../../../src/api/auth/register.service'
+
+const server = setupServer(registerHandler)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('register service', () => {
+  test('fails when email already exists', async () => {
+    await expect(
+      register({ name: 'User', email: DEFAULT_EMAIL, password: 'pass' })
+    ).rejects.toMatchObject({
+      response: { status: 409, data: { error: 'EmailExists' } },
+    })
+  })
+
+  test('registers successfully with new email', async () => {
+    const response = await register({
+      name: 'User',
+      email: 'unique@example.com',
+      password: 'pass',
+    })
+    expect(response).toMatchObject({ message: 'auth.success.register' })
+  })
+})

--- a/tests/pages/login/LoginPage.test.tsx
+++ b/tests/pages/login/LoginPage.test.tsx
@@ -19,5 +19,6 @@ describe('LoginPage', () => {
   test('renders login form', () => {
     renderWithProviders(<LoginPage />)
     expect(screen.getByText('Mocked LoginForm')).toBeVisible()
+    expect(screen.getByText('register')).toBeVisible()
   })
 })

--- a/tests/pages/register/RegisterPage.test.tsx
+++ b/tests/pages/register/RegisterPage.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../../src/api/auth/me.service', () => ({
+  fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+}))
+
+vi.mock('../../../src/components/register/RegisterForm', () => ({
+  RegisterForm: ({ onSubmit }: { onSubmit?: (data: unknown) => void }) => {
+    onSubmit?.({})
+    return <div>Mocked RegisterForm</div>
+  },
+}))
+
+import RegisterPage from '../../../src/pages/register/RegisterPage'
+import { renderWithProviders } from '../../test-utils'
+
+describe('RegisterPage', () => {
+  test('renders register form', () => {
+    renderWithProviders(<RegisterPage />)
+    expect(screen.getByText('Mocked RegisterForm')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- add register page and form with validation
- expose API route and hook to register users
- support registration in msw with duplicate email check

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41f730d68832e809ae012aa4ffad2