### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <HTMLCodeStyleSettings>
       <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </HTMLCodeStyleSettings>


### PR DESCRIPTION
## Summary
- normalize text line endings with .gitattributes
- set IntelliJ project line separator to LF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4a6dac6c0832e9eeb58d677d90004