### PR TITLE
Use @src alias in tests

### DIFF
--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,13 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-import { fetchMe } from '../src/api/auth/me.service'
-import App from '../src/App'
-vi.mock('../src/hooks/api/useBooks', () => ({
+import { fetchMe } from '@src/api/auth/me.service'
+import App from '@src/App'
+vi.mock('@src/hooks/api/useBooks', () => ({
   useBooks: () => ({ data: [] }),
 }))
-
-vi.mock('../src/api/auth/me.service', () => ({ fetchMe: vi.fn() }))
+vi.mock('@src/api/auth/me.service', () => ({ fetchMe: vi.fn() }))
 
 describe('App Component', () => {
   test('renders correctly for guest users', async () => {

--- a/tests/assets/index.test.tsx
+++ b/tests/assets/index.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
-import { Logo } from '../../src/assets'
+import { Logo } from '@src/assets'
 
 describe('assets index', () => {
   test('exports Logo component', () => {

--- a/tests/components/book/BookCard.test.tsx
+++ b/tests/components/book/BookCard.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
-import { BookCard } from '../../../src/components/book/BookCard'
+import { BookCard } from '@src/components/book/BookCard'
 import { renderWithProviders } from '../../test-utils'
 
 describe('BookCard', () => {

--- a/tests/components/book/BookCard.test.tsx
+++ b/tests/components/book/BookCard.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
 import { BookCard } from '@src/components/book/BookCard'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('BookCard', () => {

--- a/tests/components/login/LoginForm.test.tsx
+++ b/tests/components/login/LoginForm.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test, vi, beforeEach } from 'vitest'
 const mockMutate = vi.fn()
 const navigate = vi.fn()
 
-vi.mock('../../../src/hooks/api/useLogin', () => ({
+vi.mock('@src/hooks/api/useLogin', () => ({
   useLogin: () => ({ mutate: mockMutate, isPending: false }),
 }))
 
@@ -14,12 +14,12 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => navigate }
 })
 
-vi.mock('../../../src/components/ui/toaster/Toaster', () => ({
+vi.mock('@src/components/ui/toaster/Toaster', () => ({
   showToast: vi.fn(),
 }))
 
-import { LoginForm } from '../../../src/components/login/LoginForm'
-import { showToast } from '../../../src/components/ui/toaster/Toaster'
+import { LoginForm } from '@src/components/login/LoginForm'
+import { showToast } from '@src/components/ui/toaster/Toaster'
 import { renderWithProviders } from '../../test-utils'
 
 const showToastMock = vi.mocked(showToast)

--- a/tests/components/login/LoginForm.test.tsx
+++ b/tests/components/login/LoginForm.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@src/components/ui/toaster/Toaster', () => ({
 
 import { LoginForm } from '@src/components/login/LoginForm'
 import { showToast } from '@src/components/ui/toaster/Toaster'
+
 import { renderWithProviders } from '../../test-utils'
 
 const showToastMock = vi.mocked(showToast)

--- a/tests/components/register/RegisterForm.test.tsx
+++ b/tests/components/register/RegisterForm.test.tsx
@@ -3,16 +3,16 @@ import { describe, expect, test, vi, beforeEach } from 'vitest'
 
 const mockMutate = vi.fn()
 
-vi.mock('../../../src/hooks/api/useRegister', () => ({
+vi.mock('@src/hooks/api/useRegister', () => ({
   useRegister: () => ({ mutate: mockMutate, isPending: false }),
 }))
 
-vi.mock('../../../src/components/ui/toaster/Toaster', () => ({
+vi.mock('@src/components/ui/toaster/Toaster', () => ({
   showToast: vi.fn(),
 }))
 
-import { RegisterForm } from '../../../src/components/register/RegisterForm'
-import { showToast } from '../../../src/components/ui/toaster/Toaster'
+import { RegisterForm } from '@src/components/register/RegisterForm'
+import { showToast } from '@src/components/ui/toaster/Toaster'
 import { renderWithProviders } from '../../test-utils'
 
 describe('RegisterForm', () => {

--- a/tests/components/register/RegisterForm.test.tsx
+++ b/tests/components/register/RegisterForm.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@src/components/ui/toaster/Toaster', () => ({
 
 import { RegisterForm } from '@src/components/register/RegisterForm'
 import { showToast } from '@src/components/ui/toaster/Toaster'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('RegisterForm', () => {

--- a/tests/components/sidebar/Sidebar.test.tsx
+++ b/tests/components/sidebar/Sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
-import { Sidebar } from '../../../src/components/sidebar/Sidebar'
+import { Sidebar } from '@src/components/sidebar/Sidebar'
 import { renderWithProviders } from '../../test-utils'
 
 describe('Sidebar', () => {

--- a/tests/components/sidebar/Sidebar.test.tsx
+++ b/tests/components/sidebar/Sidebar.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
 import { Sidebar } from '@src/components/sidebar/Sidebar'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('Sidebar', () => {

--- a/tests/components/sidebar/SidebarLanguageSwitcher.test.tsx
+++ b/tests/components/sidebar/SidebarLanguageSwitcher.test.tsx
@@ -11,6 +11,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 import { SidebarLanguageSwitcher } from '@src/components/sidebar/buttons/SidebarLanguageSwitcher'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('SidebarLanguageSwitcher', () => {

--- a/tests/components/sidebar/SidebarLanguageSwitcher.test.tsx
+++ b/tests/components/sidebar/SidebarLanguageSwitcher.test.tsx
@@ -10,7 +10,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-import { SidebarLanguageSwitcher } from '../../../src/components/sidebar/buttons/SidebarLanguageSwitcher'
+import { SidebarLanguageSwitcher } from '@src/components/sidebar/buttons/SidebarLanguageSwitcher'
 import { renderWithProviders } from '../../test-utils'
 
 describe('SidebarLanguageSwitcher', () => {

--- a/tests/components/theme/ThemeIconButton.test.tsx
+++ b/tests/components/theme/ThemeIconButton.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import { ThemeIconButton } from '@src/components/theme/ThemeIconButton'
 import * as useThemeModule from '@src/hooks/theme/useTheme'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('ThemeIconButton', () => {

--- a/tests/components/theme/ThemeIconButton.test.tsx
+++ b/tests/components/theme/ThemeIconButton.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-import { ThemeIconButton } from '../../../src/components/theme/ThemeIconButton'
-import * as useThemeModule from '../../../src/hooks/theme/useTheme'
+import { ThemeIconButton } from '@src/components/theme/ThemeIconButton'
+import * as useThemeModule from '@src/hooks/theme/useTheme'
 import { renderWithProviders } from '../../test-utils'
 
 describe('ThemeIconButton', () => {

--- a/tests/components/ui/toaster/Toaster.test.tsx
+++ b/tests/components/ui/toaster/Toaster.test.tsx
@@ -3,10 +3,7 @@ import { toast } from 'react-toastify'
 import type { Mock } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
 
-import {
-  Toaster,
-  showToast,
-} from '../../../../src/components/ui/toaster/Toaster'
+import { Toaster, showToast } from '@src/components/ui/toaster/Toaster'
 import { renderWithProviders } from '../../../test-utils'
 
 type ToastMock = Mock & {

--- a/tests/components/ui/toaster/Toaster.test.tsx
+++ b/tests/components/ui/toaster/Toaster.test.tsx
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
 
 import { Toaster, showToast } from '@src/components/ui/toaster/Toaster'
+
 import { renderWithProviders } from '../../../test-utils'
 
 type ToastMock = Mock & {

--- a/tests/components/ui/toggle/Toggle.test.tsx
+++ b/tests/components/ui/toggle/Toggle.test.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-import { Toggle } from '../../../../src/components/ui/toggle/Toggle'
+import { Toggle } from '@src/components/ui/toggle/Toggle'
 
 describe('Toggle', () => {
   test('does not submit the parent form when clicked', () => {

--- a/tests/hooks/theme/useTheme.test.ts
+++ b/tests/hooks/theme/useTheme.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, test } from 'vitest'
 import {
   ThemeProvider,
   useTheme as useThemeFromContext,
-} from '../../../src/contexts/theme/ThemeContext'
-import { useTheme } from '../../../src/hooks/theme/useTheme'
+} from '@src/contexts/theme/ThemeContext'
+import { useTheme } from '@src/hooks/theme/useTheme'
 
 describe('useTheme', () => {
   beforeEach(() => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,4 +1,4 @@
-import i18n from '../../src/assets/i18n/i18n'
+import i18n from '@src/assets/i18n/i18n'
 
 describe('i18n language persistence', () => {
   beforeEach(() => {

--- a/tests/pages/books/BooksPage.test.tsx
+++ b/tests/pages/books/BooksPage.test.tsx
@@ -6,6 +6,7 @@ vi.mock('@src/api/auth/me.service', () => ({
 }))
 
 import { BooksPage } from '@src/pages/books/BooksPage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('BooksPage', () => {

--- a/tests/pages/books/BooksPage.test.tsx
+++ b/tests/pages/books/BooksPage.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
 }))
 
-import { BooksPage } from '../../../src/pages/books/BooksPage'
+import { BooksPage } from '@src/pages/books/BooksPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('BooksPage', () => {

--- a/tests/pages/community/CommunityPage.test.tsx
+++ b/tests/pages/community/CommunityPage.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
 }))
 
-import { CommunityPage } from '../../../src/pages/community/CommunityPage'
+import { CommunityPage } from '@src/pages/community/CommunityPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('CommunityPage', () => {

--- a/tests/pages/community/CommunityPage.test.tsx
+++ b/tests/pages/community/CommunityPage.test.tsx
@@ -5,6 +5,7 @@ vi.mock('@src/api/auth/me.service', () => ({
 }))
 
 import { CommunityPage } from '@src/pages/community/CommunityPage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('CommunityPage', () => {

--- a/tests/pages/contact/ContactPage.test.tsx
+++ b/tests/pages/contact/ContactPage.test.tsx
@@ -6,6 +6,7 @@ vi.mock('@src/api/auth/me.service', () => ({
 }))
 
 import { ContactPage } from '@src/pages/contact/ContactPage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('ContactPage', () => {

--- a/tests/pages/contact/ContactPage.test.tsx
+++ b/tests/pages/contact/ContactPage.test.tsx
@@ -1,11 +1,11 @@
 import { screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
 }))
 
-import { ContactPage } from '../../../src/pages/contact/ContactPage'
+import { ContactPage } from '@src/pages/contact/ContactPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('ContactPage', () => {

--- a/tests/pages/home/HomePage.test.tsx
+++ b/tests/pages/home/HomePage.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn(),
 }))
 
 const useBooksMock = vi.fn()
-vi.mock('../../../src/hooks/api/useBooks', () => ({
+vi.mock('@src/hooks/api/useBooks', () => ({
   useBooks: () => useBooksMock(),
 }))
 
@@ -14,8 +14,8 @@ beforeEach(() => {
   useBooksMock.mockReturnValue({ data: [] })
 })
 
-import { fetchMe } from '../../../src/api/auth/me.service'
-import { HomePage } from '../../../src/pages/home/HomePage'
+import { fetchMe } from '@src/api/auth/me.service'
+import { HomePage } from '@src/pages/home/HomePage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('HomePage', () => {

--- a/tests/pages/home/HomePage.test.tsx
+++ b/tests/pages/home/HomePage.test.tsx
@@ -16,6 +16,7 @@ beforeEach(() => {
 
 import { fetchMe } from '@src/api/auth/me.service'
 import { HomePage } from '@src/pages/home/HomePage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('HomePage', () => {

--- a/tests/pages/login/LoginPage.test.tsx
+++ b/tests/pages/login/LoginPage.test.tsx
@@ -1,18 +1,18 @@
 import { screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
 }))
 
-vi.mock('../../../src/components/login/LoginForm', () => ({
+vi.mock('@src/components/login/LoginForm', () => ({
   LoginForm: ({ onSubmit }: { onSubmit?: (data: unknown) => void }) => {
     onSubmit?.({})
     return <div>Mocked LoginForm</div>
   },
 }))
 
-import LoginPage from '../../../src/pages/login/LoginPage'
+import LoginPage from '@src/pages/login/LoginPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('LoginPage', () => {

--- a/tests/pages/login/LoginPage.test.tsx
+++ b/tests/pages/login/LoginPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@src/components/login/LoginForm', () => ({
 }))
 
 import LoginPage from '@src/pages/login/LoginPage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('LoginPage', () => {

--- a/tests/pages/not_found/NotFound.test.tsx
+++ b/tests/pages/not_found/NotFound.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
-import NotFound from '../../../src/pages/not_found/NotFound'
+import NotFound from '@src/pages/not_found/NotFound'
 
 describe('NotFound page', () => {
   test('shows 404 message', () => {

--- a/tests/pages/register/RegisterPage.test.tsx
+++ b/tests/pages/register/RegisterPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock('react-router-dom', async () => {
 })
 
 import RegisterPage from '@src/pages/register/RegisterPage'
+
 import { renderWithProviders } from '../../test-utils'
 
 describe('RegisterPage', () => {

--- a/tests/pages/register/RegisterPage.test.tsx
+++ b/tests/pages/register/RegisterPage.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, screen } from '@testing-library/react'
 import { useNavigate } from 'react-router-dom'
 import { describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../src/api/auth/me.service', () => ({
+vi.mock('@src/api/auth/me.service', () => ({
   fetchMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
 }))
 
-vi.mock('../../../src/components/register/RegisterForm', () => ({
+vi.mock('@src/components/register/RegisterForm', () => ({
   RegisterForm: ({ onSubmit }: { onSubmit?: () => void }) => (
     <button onClick={onSubmit}>Mocked RegisterForm</button>
   ),
@@ -18,7 +18,7 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: vi.fn() }
 })
 
-import RegisterPage from '../../../src/pages/register/RegisterPage'
+import RegisterPage from '@src/pages/register/RegisterPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('RegisterPage', () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,7 +2,7 @@ import 'tsconfig-paths/register'
 import '@testing-library/jest-dom'
 import { afterAll, afterEach, beforeAll, vi } from 'vitest'
 
-import { server } from '../mocks/server'
+import { server } from '@mocks/server'
 
 // Mock SVGs
 vi.mock('.*\\.svg$', () => ({

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react'
 import { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
-import { AuthProvider } from '../src/contexts/auth/AuthContext'
-import { ThemeProvider } from '../src/contexts/theme/ThemeContext'
+import { AuthProvider } from '@src/contexts/auth/AuthContext'
+import { ThemeProvider } from '@src/contexts/theme/ThemeContext'
 
 export const createWrapper = () => {
   const queryClient = new QueryClient({


### PR DESCRIPTION
## Summary
- replace relative `../src` imports with `@src` alias in tests
- update test setup to import mocks via `@mocks`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6d3cb60832e820f837735ce2a30