### PR TITLE
chore: add jest-dom matchers for vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "jsdom": "^26.1.0",
         "msw": "^2.10.4",
-        "prettier": "^3.6.2",
+        "prettier": "3.6.2",
         "sass": "^1.89.2",
         "sass-loader": "^16.0.5",
         "style-loader": "^4.0.0",

--- a/tests/components/register/RegisterForm.test.tsx
+++ b/tests/components/register/RegisterForm.test.tsx
@@ -16,10 +16,12 @@ import { showToast } from '@src/components/ui/toaster/Toaster'
 
 import { renderWithProviders } from '../../test-utils'
 
+const showToastMock = vi.mocked(showToast)
+
 describe('RegisterForm', () => {
   beforeEach(() => {
     mockMutate.mockReset()
-    showToast.mockReset()
+    showToastMock.mockReset()
   })
 
   test('shows validation errors for required fields', async () => {
@@ -73,7 +75,10 @@ describe('RegisterForm', () => {
     await screen.findByRole('button', { name: 'register' })
     expect(mockMutate).toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalled()
-    expect(showToast).toHaveBeenCalledWith('auth.success.register', 'success')
+    expect(showToastMock).toHaveBeenCalledWith(
+      'auth.success.register',
+      'success'
+    )
   })
 
   test('shows server error message on failure', async () => {
@@ -98,6 +103,6 @@ describe('RegisterForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'register' }))
 
     await screen.findByRole('button', { name: 'register' })
-    expect(showToast).toHaveBeenCalledWith('auth.errors.unknown', 'error')
+    expect(showToastMock).toHaveBeenCalledWith('auth.errors.unknown', 'error')
   })
 })

--- a/tests/utils/cookies.test.ts
+++ b/tests/utils/cookies.test.ts
@@ -17,7 +17,6 @@ describe('clearAllCookies', () => {
 
   test('handles missing document gracefully', () => {
     const original = global.document
-    // @ts-expect-error - simulate environment without document
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (global as any).document
     expect(() => clearAllCookies()).not.toThrow()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,9 +22,9 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "vitest"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist", "build", "coverage"],
-  "include": ["src", "mocks"]
+  "include": ["vitest.d.ts", "src", "tests", "mocks"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist", "build", "coverage"],
-  "include": ["vitest.d.ts", "src", "tests", "mocks"]
+  "include": ["src", "tests", "mocks"]
 }

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,8 +1,0 @@
-/// <reference types="vitest" />
-import '@testing-library/jest-dom'
-
-declare global {
-  namespace Vi {
-    interface Assertion<T = unknown> extends jest.Matchers<void, T> {}
-  }
-}

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import '@testing-library/jest-dom'
+
+declare global {
+  namespace Vi {
+    interface Assertion<T = unknown> extends jest.Matchers<void, T> {}
+  }
+}


### PR DESCRIPTION
## Summary
- include jest-dom matchers so `toBeVisible` works with Vitest
- configure TypeScript to pick up test typings

## Testing
- `npm test`
- `npm run typecheck` *(fails: Module '"vitest"' has no exported member 'describe')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e95f348c832e86d3769e356e3743