### PR TITLE
refactor: unify tabs menus for books and community

### DIFF
--- a/src/components/ui/tabs-menu/TabsMenu.module.scss
+++ b/src/components/ui/tabs-menu/TabsMenu.module.scss
@@ -1,0 +1,28 @@
+@import '@styles/variables';
+
+.tabs {
+  display: flex;
+  gap: $spacing-1;
+  border-bottom: rem(1px) solid var(--border-color);
+  overflow: hidden;
+
+  @media (max-width: $breakpoint-mobile) {
+    overflow-x: auto;
+  }
+}
+
+.tab {
+  background: none;
+  border: none;
+  padding: $spacing-1 $spacing-2;
+  cursor: pointer;
+  font-weight: $font-weight-medium;
+  font-size: $h6-font-size;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.tab.active {
+  color: var(--primary-color);
+  border-bottom: rem(2px) solid var(--primary-color);
+}

--- a/src/components/ui/tabs-menu/TabsMenu.tsx
+++ b/src/components/ui/tabs-menu/TabsMenu.tsx
@@ -19,7 +19,7 @@ export const TabsMenu = ({
         const isActive = location.pathname === fullPath
         return (
           <Link
-            key={fullPath}
+            key={`${basePath}:${item.path}`}
             to={fullPath}
             className={`${styles.tab} ${isActive ? styles.active : ''}`}
             role="tab"

--- a/src/components/ui/tabs-menu/TabsMenu.tsx
+++ b/src/components/ui/tabs-menu/TabsMenu.tsx
@@ -1,0 +1,29 @@
+import { Link, useLocation } from 'react-router-dom'
+
+import styles from './TabsMenu.module.scss'
+import type { TabsMenuProps } from './TabsMenu.types'
+
+export const TabsMenu = ({ items, basePath = '', className, children }: TabsMenuProps) => {
+  const location = useLocation()
+
+  return (
+    <nav className={`${styles.tabs} ${className ?? ''}`} role="tablist">
+      {items.map((item) => {
+        const fullPath = `${basePath}${item.path ? `/${item.path}` : ''}`
+        const isActive = location.pathname === fullPath
+        return (
+          <Link
+            key={item.path || item.label}
+            to={fullPath}
+            className={`${styles.tab} ${isActive ? styles.active : ''}`}
+            role="tab"
+            aria-selected={isActive}
+          >
+            {item.label}
+          </Link>
+        )
+      })}
+      {children}
+    </nav>
+  )
+}

--- a/src/components/ui/tabs-menu/TabsMenu.tsx
+++ b/src/components/ui/tabs-menu/TabsMenu.tsx
@@ -3,7 +3,12 @@ import { Link, useLocation } from 'react-router-dom'
 import styles from './TabsMenu.module.scss'
 import type { TabsMenuProps } from './TabsMenu.types'
 
-export const TabsMenu = ({ items, basePath = '', className, children }: TabsMenuProps) => {
+export const TabsMenu = ({
+  items,
+  basePath = '',
+  className,
+  children,
+}: TabsMenuProps) => {
   const location = useLocation()
 
   return (

--- a/src/components/ui/tabs-menu/TabsMenu.tsx
+++ b/src/components/ui/tabs-menu/TabsMenu.tsx
@@ -14,12 +14,12 @@ export const TabsMenu = ({
 
   return (
     <nav className={`${styles.tabs} ${className ?? ''}`} role="tablist">
-      {items.map((item, index) => {
+      {items.map((item) => {
         const fullPath = buildFullPath(basePath, item.path)
         const isActive = location.pathname === fullPath
         return (
           <Link
-            key={index}
+            key={fullPath}
             to={fullPath}
             className={`${styles.tab} ${isActive ? styles.active : ''}`}
             role="tab"

--- a/src/components/ui/tabs-menu/TabsMenu.tsx
+++ b/src/components/ui/tabs-menu/TabsMenu.tsx
@@ -1,3 +1,4 @@
+import { buildFullPath } from '@utils/path'
 import { Link, useLocation } from 'react-router-dom'
 
 import styles from './TabsMenu.module.scss'
@@ -13,12 +14,12 @@ export const TabsMenu = ({
 
   return (
     <nav className={`${styles.tabs} ${className ?? ''}`} role="tablist">
-      {items.map((item) => {
-        const fullPath = `${basePath}${item.path ? `/${item.path}` : ''}`
+      {items.map((item, index) => {
+        const fullPath = buildFullPath(basePath, item.path)
         const isActive = location.pathname === fullPath
         return (
           <Link
-            key={item.path || item.label}
+            key={index}
             to={fullPath}
             className={`${styles.tab} ${isActive ? styles.active : ''}`}
             role="tab"

--- a/src/components/ui/tabs-menu/TabsMenu.types.ts
+++ b/src/components/ui/tabs-menu/TabsMenu.types.ts
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export interface TabItem {
+  path: string
+  label: string
+}
+
+export interface TabsMenuProps {
+  items: TabItem[]
+  basePath?: string
+  className?: string
+  children?: ReactNode
+}

--- a/src/components/ui/tabs-menu/TabsMenu.types.ts
+++ b/src/components/ui/tabs-menu/TabsMenu.types.ts
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
 
-export interface TabItem {
+export type TabItem = {
   path: string
   label: string
 }
 
-export interface TabsMenuProps {
+export type TabsMenuProps = {
   items: TabItem[]
   basePath?: string
   className?: string

--- a/src/pages/books/BooksPage.module.scss
+++ b/src/pages/books/BooksPage.module.scss
@@ -62,32 +62,6 @@
   }
 }
 
-.tabs {
-  display: flex;
-  gap: $spacing-1;
-  border-bottom: 1px solid var(--border-color);
-  overflow: hidden;
-
-  @media (max-width: $breakpoint-mobile) {
-    overflow-x: auto;
-  }
-}
-
-.tab {
-  background: none;
-  border: none;
-  padding: $spacing-1 $spacing-2;
-  cursor: pointer;
-  font-weight: $font-weight-medium;
-  font-size: $h6-font-size;
-  color: var(--text-secondary);
-}
-
-.tab.active {
-  color: var(--primary-color);
-  border-bottom: rem(2px) solid var(--primary-color);
-}
-
 .seeAll {
   margin-left: auto;
   background: none;

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -1,6 +1,7 @@
 import { BookCard } from '@components/book/BookCard'
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
 import { TabsMenu } from '@components/ui/tabs-menu/TabsMenu'
+import { getPathSegment } from '@utils/path'
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
@@ -78,7 +79,7 @@ export const BooksPage = () => {
     [t]
   )
 
-  const pathSegment = location.pathname.replace(basePath, '').replace(/^\//, '')
+  const pathSegment = getPathSegment(location.pathname, basePath)
   const activeTab = (tabs.find((tab) => tab.path === pathSegment)?.key ??
     'mine') as 'mine' | 'trade' | 'seeking' | 'sale'
 

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -71,7 +71,7 @@ export const BooksPage = () => {
 
   const tabs = useMemo(
     () => [
-      { key: 'mine', path: '', label: t('booksPage.tabs.mine') },
+      { key: 'mine', path: 'mine', label: t('booksPage.tabs.mine') },
       { key: 'trade', path: 'trade', label: t('booksPage.tabs.for_trade') },
       { key: 'seeking', path: 'seeking', label: t('booksPage.tabs.seeking') },
       { key: 'sale', path: 'sale', label: t('booksPage.tabs.for_sale') },

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -1,7 +1,9 @@
 import { BookCard } from '@components/book/BookCard'
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
+import { TabsMenu } from '@components/ui/tabs-menu/TabsMenu'
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router-dom'
 
 import styles from './BooksPage.module.scss'
 import type { Book } from './BooksPage.types'
@@ -61,20 +63,27 @@ const mockBooks: Book[] = [
 
 export const BooksPage = () => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState<
-    'mine' | 'trade' | 'seeking' | 'sale'
-  >('mine')
+  const location = useLocation()
   const [search, setSearch] = useState('')
+
+  const basePath = '/books'
 
   const tabs = useMemo(
     () => [
-      { key: 'mine', label: t('booksPage.tabs.mine') },
-      { key: 'trade', label: t('booksPage.tabs.for_trade') },
-      { key: 'seeking', label: t('booksPage.tabs.seeking') },
-      { key: 'sale', label: t('booksPage.tabs.for_sale') },
+      { key: 'mine', path: '', label: t('booksPage.tabs.mine') },
+      { key: 'trade', path: 'trade', label: t('booksPage.tabs.for_trade') },
+      { key: 'seeking', path: 'seeking', label: t('booksPage.tabs.seeking') },
+      { key: 'sale', path: 'sale', label: t('booksPage.tabs.for_sale') },
     ],
     [t]
   )
+
+  const pathSegment = location.pathname
+    .replace(basePath, '')
+    .replace(/^\//, '')
+  const activeTab = (
+    tabs.find((tab) => tab.path === pathSegment)?.key ?? 'mine'
+  ) as 'mine' | 'trade' | 'seeking' | 'sale'
 
   // TODO: mover este filtro a un hook reutilizable si se complica
   const filterByTab = (book: Book) => {
@@ -122,22 +131,11 @@ export const BooksPage = () => {
           </div>
         </header>
 
-        <div className={styles.tabs} role="tablist">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              role="tab"
-              aria-selected={activeTab === tab.key}
-              className={`${styles.tab} ${activeTab === tab.key ? styles.active : ''}`}
-              onClick={() => setActiveTab(tab.key as typeof activeTab)}
-            >
-              {tab.label}
-            </button>
-          ))}
+        <TabsMenu items={tabs} basePath={basePath}>
           <button className={styles.seeAll}>
             {t('booksPage.tabs.see_all')}
           </button>
-        </div>
+        </TabsMenu>
 
         {filteredBooks.length === 0 ? (
           <div className={styles.empty}>

--- a/src/pages/books/BooksPage.tsx
+++ b/src/pages/books/BooksPage.tsx
@@ -78,12 +78,9 @@ export const BooksPage = () => {
     [t]
   )
 
-  const pathSegment = location.pathname
-    .replace(basePath, '')
-    .replace(/^\//, '')
-  const activeTab = (
-    tabs.find((tab) => tab.path === pathSegment)?.key ?? 'mine'
-  ) as 'mine' | 'trade' | 'seeking' | 'sale'
+  const pathSegment = location.pathname.replace(basePath, '').replace(/^\//, '')
+  const activeTab = (tabs.find((tab) => tab.path === pathSegment)?.key ??
+    'mine') as 'mine' | 'trade' | 'seeking' | 'sale'
 
   // TODO: mover este filtro a un hook reutilizable si se complica
   const filterByTab = (book: Book) => {

--- a/src/pages/community/CommunityPage.module.scss
+++ b/src/pages/community/CommunityPage.module.scss
@@ -12,33 +12,6 @@
   gap: $spacing-2;
 }
 
-.tabs {
-  display: flex;
-  gap: $spacing-1;
-  border-bottom: rem(1px) solid var(--border-color);
-  overflow: hidden;
-
-  @media (max-width: $breakpoint-mobile) {
-    overflow-x: auto;
-  }
-}
-
-.tab {
-  background: none;
-  border: none;
-  padding: $spacing-1 $spacing-2;
-  cursor: pointer;
-  font-weight: $font-weight-medium;
-  font-size: $h6-font-size;
-  color: var(--text-secondary);
-  text-decoration: none;
-}
-
-.tab.active {
-  color: var(--primary-color);
-  border-bottom: rem(2px) solid var(--primary-color);
-}
-
 .tabContent {
   padding: $spacing-1 0;
 }

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
+import { TabsMenu } from '@components/ui/tabs-menu/TabsMenu'
 import { useTranslation } from 'react-i18next'
-import { Link, Route, Routes, useLocation } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import styles from './CommunityPage.module.scss'
 import { ActivityTab } from './tabs/ActivityTab'
@@ -9,11 +10,8 @@ import { ForumsTab } from './tabs/ForumsTab'
 import { MessagesTab } from './tabs/MessagesTab'
 import { StatsTab } from './tabs/StatsTab'
 
-const ACTIVITY_TAB_KEY = 'activity'
-
 export const CommunityPage = () => {
   const { t } = useTranslation()
-  const location = useLocation()
   const basePath = '/community'
 
   const tabs = [
@@ -31,23 +29,7 @@ export const CommunityPage = () => {
           <h1>{t('community.title')}</h1>
         </header>
 
-        <nav className={styles.tabs} role="tablist">
-          {tabs.map((tab) => {
-            const fullPath = `${basePath}${tab.path ? `/${tab.path}` : ''}`
-            const isActive = location.pathname === fullPath
-            return (
-              <Link
-                key={tab.path || ACTIVITY_TAB_KEY}
-                to={fullPath}
-                className={`${styles.tab} ${isActive ? styles.active : ''}`}
-                role="tab"
-                aria-selected={isActive}
-              >
-                {tab.label}
-              </Link>
-            )
-          })}
-        </nav>
+        <TabsMenu items={tabs} basePath={basePath} />
 
         <Routes>
           <Route index element={<ActivityTab />} />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -24,7 +24,7 @@ const AppRoutes = () => {
           <Route path={`/${HOME_URLS.HOME}`} element={<HomePage />} />
         </Route>
         <Route element={<BaseLayout />}>
-          <Route path={`/${HOME_URLS.BOOKS}`} element={<BooksPage />} />
+          <Route path={`/${HOME_URLS.BOOKS}/*`} element={<BooksPage />} />
         </Route>
         <Route element={<BaseLayout />}>
           <Route

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -8,7 +8,7 @@ export const buildFullPath = (basePath: string, subPath?: string) => {
 }
 
 export const getPathSegment = (pathname: string, basePath: string) => {
-  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}`
+  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`
   const withoutBase = pathname.startsWith(normalizedBase)
     ? pathname.slice(normalizedBase.length)
     : pathname

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,16 @@
+export const buildFullPath = (basePath: string, subPath?: string) => {
+  const normalizedBase = basePath.endsWith('/')
+    ? basePath.slice(0, -1)
+    : basePath
+  if (!subPath) return normalizedBase
+  const normalizedSub = subPath.startsWith('/') ? subPath.slice(1) : subPath
+  return `${normalizedBase}/${normalizedSub}`
+}
+
+export const getPathSegment = (pathname: string, basePath: string) => {
+  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}`
+  const withoutBase = pathname.startsWith(normalizedBase)
+    ? pathname.slice(normalizedBase.length)
+    : pathname
+  return withoutBase.replace(/^\/+/, '').replace(/\/+$/, '')
+}


### PR DESCRIPTION
## Summary
- create reusable TabsMenu component for shared tab navigation
- switch books and community pages to TabsMenu and sync URL state
- allow nested book routes with updated routing

## Testing
- `npm test`
- `npm run lint`
- `npm run stylelint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a513beeee8832ea94606a3bc776060