### PR TITLE
refactor: modularize community events with services and msw

### DIFF
--- a/mocks/handlers/events/events.handler.ts
+++ b/mocks/handlers/events/events.handler.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw'
+
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import eventsResponse from './fixtures/events.json'
+import metricsResponse from './fixtures/metrics.json'
+
+export const eventsHandler = http.get(
+  RELATIVE_API_ROUTES.EVENTS.LIST,
+  async () => {
+    await new Promise((r) => setTimeout(r, 200))
+    return HttpResponse.json(eventsResponse, { status: 200 })
+  }
+)
+
+export const eventsMetricsHandler = http.get(
+  RELATIVE_API_ROUTES.EVENTS.METRICS,
+  async () => {
+    await new Promise((r) => setTimeout(r, 200))
+    return HttpResponse.json(metricsResponse, { status: 200 })
+  }
+)

--- a/mocks/handlers/events/fixtures/events.json
+++ b/mocks/handlers/events/fixtures/events.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "1",
+    "title": "Club de lectura Borges",
+    "date": "2024-08-24T18:00:00",
+    "location": "Casita Av. Sevilla 123",
+    "description": "Lectura y debate sobre relatos de Borges.",
+    "status": "upcoming",
+    "imageUrl": "https://picsum.photos/seed/event1/400/200"
+  },
+  {
+    "id": "2",
+    "title": "Feria de intercambio de libros",
+    "date": "2024-09-10T10:00:00",
+    "location": "Plaza Central",
+    "description": "Traé tus libros y encontrá nuevas lecturas.",
+    "status": "upcoming",
+    "imageUrl": "https://picsum.photos/seed/event2/400/200"
+  },
+  {
+    "id": "3",
+    "title": "Taller de escritura creativa",
+    "date": "2024-07-15T15:00:00",
+    "location": "Casita Rivadavia 456",
+    "description": "Ejercicios para estimular la imaginación.",
+    "status": "ongoing",
+    "imageUrl": "https://picsum.photos/seed/event3/400/200"
+  },
+  {
+    "id": "4",
+    "title": "Presentación de autores locales",
+    "date": "2024-05-20T17:00:00",
+    "location": "Biblioteca Municipal",
+    "description": "Conoce a escritores emergentes de la zona.",
+    "status": "past",
+    "imageUrl": "https://picsum.photos/seed/event4/400/200"
+  },
+  {
+    "id": "5",
+    "title": "Encuentro de poesía",
+    "date": "2024-05-30T19:00:00",
+    "location": "Casita del Parque",
+    "description": "Micrófono abierto para poetas.",
+    "status": "past",
+    "imageUrl": "https://picsum.photos/seed/event5/400/200"
+  },
+  {
+    "id": "6",
+    "title": "Maratón de lectura solidaria",
+    "date": "2024-07-01T09:00:00",
+    "location": "Centro Cultural",
+    "description": "Leemos para recaudar fondos para bibliotecas.",
+    "status": "upcoming",
+    "imageUrl": "https://picsum.photos/seed/event6/400/200"
+  },
+  {
+    "id": "7",
+    "title": "Noche de relatos de terror",
+    "date": "2024-06-15T22:00:00",
+    "location": "Casita Corrientes 789",
+    "description": "Lectura colectiva de cuentos de terror.",
+    "status": "ongoing",
+    "imageUrl": "https://picsum.photos/seed/event7/400/200"
+  }
+]

--- a/mocks/handlers/events/fixtures/metrics.json
+++ b/mocks/handlers/events/fixtures/metrics.json
@@ -1,0 +1,5 @@
+{
+  "eventsThisMonth": 12,
+  "hostHouses": 8,
+  "confirmedUsers": 57
+}

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -4,6 +4,7 @@ import { authStateHandler, meHandler } from './auth/me.handler'
 import { registerHandler } from './auth/register.handler'
 import { booksHandler } from './books/books.handler'
 import { contactFormHandler } from './contactForm/contactForm.handler'
+import { eventsHandler, eventsMetricsHandler } from './events/events.handler'
 
 export const handlers = [
   loginHandler,
@@ -13,4 +14,6 @@ export const handlers = [
   meHandler,
   booksHandler,
   contactFormHandler,
+  eventsHandler,
+  eventsMetricsHandler,
 ]

--- a/src/api/events/events.service.ts
+++ b/src/api/events/events.service.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@src/api/axios'
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import { ApiEvent, ApiEventsMetrics } from './events.types'
+
+export const fetchEvents = async (): Promise<ApiEvent[]> => {
+  const { data } = await apiClient.get<ApiEvent[]>(RELATIVE_API_ROUTES.EVENTS.LIST)
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid events response')
+  }
+  return data
+}
+
+export const fetchEventsMetrics = async (): Promise<ApiEventsMetrics> => {
+  const { data } = await apiClient.get<ApiEventsMetrics>(
+    RELATIVE_API_ROUTES.EVENTS.METRICS
+  )
+  return data
+}

--- a/src/api/events/events.types.ts
+++ b/src/api/events/events.types.ts
@@ -1,0 +1,17 @@
+export type EventStatus = 'upcoming' | 'past' | 'ongoing'
+
+export interface ApiEvent {
+  id: string
+  title: string
+  date: string
+  location: string
+  description: string
+  status: EventStatus
+  imageUrl: string
+}
+
+export interface ApiEventsMetrics {
+  eventsThisMonth: number
+  hostHouses: number
+  confirmedUsers: number
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -12,4 +12,8 @@ export const RELATIVE_API_ROUTES = {
   BOOKS: {
     LIST: `/books`,
   },
+  EVENTS: {
+    LIST: `/community/events`,
+    METRICS: `/community/events/metrics`,
+  },
 }

--- a/src/assets/i18n/locales/en/common.json
+++ b/src/assets/i18n/locales/en/common.json
@@ -146,11 +146,70 @@
     },
     "events": {
       "title": "Events",
-      "placeholder": "Upcoming events"
+      "subtitle": "Gatherings and activities of your reading community",
+      "create": "Create event",
+      "filters": {
+        "status": {
+          "upcoming": "Upcoming",
+          "past": "Past",
+          "all": "All"
+        },
+        "nearby": "Near me"
+      },
+      "details": "View details",
+      "status": {
+        "upcoming": "Upcoming",
+        "past": "Finished",
+        "ongoing": "Ongoing"
+      },
+      "empty": {
+        "upcoming": "No upcoming events",
+        "past": "No past events",
+        "all": "No events available"
+      },
+      "explore": "Explore community",
+      "metrics": {
+        "events_this_month": "Events this month",
+        "host_houses": "Host houses",
+        "confirmed_users": "Confirmed users"
+      },
+      "image_alt": "Event banner for {{title}}"
     },
     "stats": {
       "title": "Stats",
-      "placeholder": "Sample data"
+      "subtitle": "Community overview",
+      "filters": {
+        "aria": "Select time range",
+        "7d": "7d",
+        "30d": "30d",
+        "90d": "90d",
+        "lastDays": "Last {{count}} days"
+      },
+      "kpis": {
+        "exchanges": "Exchanges",
+        "activeHouses": "Active houses",
+        "activeUsers": "Active users",
+        "booksPublished": "Books posted"
+      },
+      "trends": {
+        "exchanges": "Exchanges per day (7d)",
+        "newBooks": "New books per day (7d)"
+      },
+      "topContributors": {
+        "title": "Top contributors",
+        "metric": {
+          "exchanges": "{{count}} exchanges",
+          "books": "{{count}} books posted"
+        },
+        "viewCommunity": "View community"
+      },
+      "map": {
+        "title": "Active houses map",
+        "description": "Reference view. Interactive map coming soon."
+      },
+      "hotSearches": {
+        "title": "Trending searches"
+      }
     }
   }
 }

--- a/src/assets/i18n/locales/es/common.json
+++ b/src/assets/i18n/locales/es/common.json
@@ -146,11 +146,70 @@
     },
     "events": {
       "title": "Eventos",
-      "placeholder": "Próximos eventos"
+      "subtitle": "Encuentros y actividades de tu comunidad lectora",
+      "create": "Crear evento",
+      "filters": {
+        "status": {
+          "upcoming": "Próximos",
+          "past": "Pasados",
+          "all": "Todos"
+        },
+        "nearby": "Cerca de mí"
+      },
+      "details": "Ver detalles",
+      "status": {
+        "upcoming": "Próximo",
+        "past": "Finalizado",
+        "ongoing": "En curso"
+      },
+      "empty": {
+        "upcoming": "No hay eventos próximos",
+        "past": "No hay eventos pasados",
+        "all": "No hay eventos disponibles"
+      },
+      "explore": "Explorar comunidad",
+      "metrics": {
+        "events_this_month": "Eventos este mes",
+        "host_houses": "Casitas anfitrionas",
+        "confirmed_users": "Usuarios confirmados"
+      },
+      "image_alt": "Banner del evento {{title}}"
     },
     "stats": {
       "title": "Estadísticas",
-      "placeholder": "Datos de ejemplo"
+      "subtitle": "Visión general de la comunidad",
+      "filters": {
+        "aria": "Seleccionar rango temporal",
+        "7d": "7d",
+        "30d": "30d",
+        "90d": "90d",
+        "lastDays": "Últimos {{count}} días"
+      },
+      "kpis": {
+        "exchanges": "Intercambios",
+        "activeHouses": "Casitas activas",
+        "activeUsers": "Usuarios activos",
+        "booksPublished": "Libros publicados"
+      },
+      "trends": {
+        "exchanges": "Intercambios por día (7d)",
+        "newBooks": "Nuevos libros por día (7d)"
+      },
+      "topContributors": {
+        "title": "Top contribuidores",
+        "metric": {
+          "exchanges": "{{count}} intercambios",
+          "books": "{{count}} libros publicados"
+        },
+        "viewCommunity": "Ver comunidad"
+      },
+      "map": {
+        "title": "Mapa de casitas activas",
+        "description": "Vista referencial. En breve se habilitará el mapa interactivo."
+      },
+      "hotSearches": {
+        "title": "Lo más buscado"
+      }
     }
   }
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -10,3 +10,5 @@ export const HOME_URLS = {
   LOGIN: 'login',
   REGISTER: 'register',
 } as const
+
+export const COMMUNITY_STATS_RANGES = [7, 30, 90] as const

--- a/src/hooks/api/useEvents.ts
+++ b/src/hooks/api/useEvents.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchEvents } from '@src/api/events/events.service'
+
+export const useEvents = () =>
+  useQuery({ queryKey: ['events'], queryFn: fetchEvents })

--- a/src/hooks/api/useEventsMetrics.ts
+++ b/src/hooks/api/useEventsMetrics.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchEventsMetrics } from '@src/api/events/events.service'
+
+export const useEventsMetrics = () =>
+  useQuery({ queryKey: ['eventsMetrics'], queryFn: fetchEventsMetrics })

--- a/src/pages/community/mocks/communityStats.mock.ts
+++ b/src/pages/community/mocks/communityStats.mock.ts
@@ -1,0 +1,33 @@
+export const kpis = {
+  exchanges: 134,
+  activeHouses: 52,
+  activeUsers: 318,
+  booksPublished: 2140,
+}
+
+export const trendExchanges = [65, 80, 55, 90, 70, 40, 85]
+export const trendNewBooks = [30, 45, 35, 60, 50, 40, 55]
+
+export const topContributors = [
+  { username: '@gabriela', metric: 'exchanges', value: 12 },
+  { username: '@juanp', metric: 'books', value: 9 },
+  { username: '@maria', metric: 'exchanges', value: 8 },
+  { username: '@carlos', metric: 'books', value: 7 },
+  { username: '@ana', metric: 'exchanges', value: 6 },
+]
+
+export const hotSearches = [
+  { term: '1984', count: 23 },
+  { term: 'El Principito', count: 19 },
+  { term: 'Cortázar', count: 15 },
+  { term: 'Borges', count: 12 },
+  { term: 'Harry Potter', count: 11 },
+  { term: 'García Márquez', count: 10 },
+]
+
+export const activeHousesMapMock = [
+  { top: '20%', left: '30%' },
+  { top: '50%', left: '70%' },
+  { top: '70%', left: '40%' },
+  { top: '30%', left: '80%' },
+]

--- a/src/pages/community/tabs/EventsTab.module.scss
+++ b/src/pages/community/tabs/EventsTab.module.scss
@@ -1,0 +1,57 @@
+@import '@styles/variables';
+
+.eventsTab {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+
+  @media (min-width: $breakpoint-tablet) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.subtitle {
+  font-size: $h6-font-size;
+  color: var(--text-secondary);
+}
+
+.createButton {
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: rem(8px);
+  padding: $spacing-1x5 $spacing-3;
+  cursor: pointer;
+}
+
+.main {
+  display: grid;
+  gap: $spacing-3;
+  grid-template-columns: 1fr;
+
+  @media (min-width: $breakpoint-desktop) {
+    grid-template-columns: 3fr 1fr;
+  }
+}
+
+.grid {
+  display: grid;
+  gap: $spacing-2;
+  grid-template-columns: 1fr;
+
+  @media (min-width: $breakpoint-tablet) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: $breakpoint-desktop) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/src/pages/community/tabs/EventsTab.tsx
+++ b/src/pages/community/tabs/EventsTab.tsx
@@ -1,13 +1,63 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import styles from '../CommunityPage.module.scss'
+import { EventStatus } from '@src/api/events/events.types'
+import { useEvents } from '@src/hooks/api/useEvents'
+import { useEventsMetrics } from '@src/hooks/api/useEventsMetrics'
+
+import communityStyles from '../CommunityPage.module.scss'
+import styles from './EventsTab.module.scss'
+import { EventsFilters } from './events/EventsFilters'
+import { EventCard } from './events/EventCard'
+import { EventsMetrics } from './events/EventsMetrics'
+import { EventsEmptyState } from './events/EventsEmptyState'
 
 export const EventsTab = () => {
   const { t } = useTranslation()
+  const [statusFilter, setStatusFilter] = useState<EventStatus | 'all'>('upcoming')
+  const [nearby, setNearby] = useState(false)
+
+  const { data: events = [] } = useEvents()
+  const { data: metrics } = useEventsMetrics()
+
+  const filteredEvents = events.filter((event) => {
+    if (statusFilter === 'all') return true
+    return event.status === statusFilter
+  })
+
   return (
-    <section className={styles.tabContent}>
-      <h2>{t('community.events.title')}</h2>
-      <p>{t('community.events.placeholder')}</p>
+    <section className={`${communityStyles.tabContent} ${styles.eventsTab}`}>
+      <header className={styles.header}>
+        <div>
+          <h2>{t('community.events.title')}</h2>
+          <p className={styles.subtitle}>{t('community.events.subtitle')}</p>
+        </div>
+        <button className={styles.createButton}>
+          {t('community.events.create')}
+        </button>
+      </header>
+
+      <EventsFilters
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+        nearby={nearby}
+        onToggleNearby={() => setNearby((p) => !p)}
+      />
+
+      <div className={styles.main}>
+        {filteredEvents.length === 0 ? (
+          <EventsEmptyState status={statusFilter} />
+        ) : (
+          <div className={styles.grid}>
+            {filteredEvents.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+        )}
+
+        {metrics && <EventsMetrics metrics={metrics} />}
+      </div>
     </section>
   )
 }
+

--- a/src/pages/community/tabs/StatsTab.module.scss
+++ b/src/pages/community/tabs/StatsTab.module.scss
@@ -1,0 +1,193 @@
+@import '@styles/variables';
+
+.stats {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.filters {
+  display: flex;
+  gap: $spacing-2;
+
+  button {
+    padding: $spacing-1 $spacing-3;
+    border: 1px solid var(--border-color);
+    background: var(--background-card);
+    border-radius: rem(12px);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background-color $transition-duration-fast
+      $transition-timing-function;
+
+    &[aria-pressed='true'] {
+      background: var(--primary-color);
+      color: #fff;
+    }
+
+    &:hover {
+      background: var(--color-neutral-200);
+    }
+  }
+}
+
+.kpiGrid {
+  display: grid;
+  gap: $spacing-3;
+  grid-template-columns: repeat(2, 1fr);
+
+  @media (min-width: $breakpoint-tablet) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.kpiCard {
+  background: var(--background-card);
+  border: 1px solid var(--border-color);
+  border-radius: rem(12px);
+  padding: $spacing-4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-2;
+  text-align: center;
+  box-shadow: var(--shadow-md);
+}
+
+.icon {
+  font-size: 1.5rem;
+}
+
+.value {
+  font-size: 2rem;
+  font-weight: $font-weight-bold;
+  color: var(--text-primary);
+}
+
+.label {
+  font-size: $h6-font-size;
+  color: var(--text-secondary);
+}
+
+.badge {
+  font-size: 0.75rem;
+  background: var(--color-neutral-200);
+  color: var(--text-secondary);
+  padding: $spacing-1 $spacing-2;
+  border-radius: rem(8px);
+}
+
+.detailsGrid {
+  display: grid;
+  gap: $spacing-3;
+  grid-template-columns: 1fr;
+
+  @media (min-width: $breakpoint-tablet) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.trendCard,
+.topContributorsCard,
+.mapCard,
+.hotSearchesCard {
+  background: var(--background-card);
+  border: 1px solid var(--border-color);
+  border-radius: rem(12px);
+  padding: $spacing-4;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+}
+
+.trendPlaceholder {
+  display: flex;
+  align-items: flex-end;
+  gap: $spacing-1;
+  height: rem(80px);
+
+  div {
+    flex: 1;
+    background: var(--primary-color);
+  }
+}
+
+.topContributorsCard ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.topContributorsCard li {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+}
+
+.avatar {
+  width: rem(32px);
+  height: rem(32px);
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: $font-weight-bold;
+}
+
+.metric {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.viewCommunity {
+  align-self: flex-start;
+  padding: $spacing-1 $spacing-3;
+  border-radius: rem(8px);
+  background: var(--primary-color);
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.mapPlaceholder {
+  position: relative;
+  height: rem(150px);
+  background-image:
+    linear-gradient(90deg, var(--border-color) 1px, transparent 1px),
+    linear-gradient(var(--border-color) 1px, transparent 1px);
+  background-size: rem(20px) rem(20px);
+}
+
+.pin {
+  position: absolute;
+  width: rem(8px);
+  height: rem(8px);
+  background: var(--primary-color);
+  border-radius: 50%;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.chip {
+  padding: $spacing-1 $spacing-2;
+  border-radius: rem(12px);
+  background: var(--color-neutral-200);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}

--- a/src/pages/community/tabs/StatsTab.tsx
+++ b/src/pages/community/tabs/StatsTab.tsx
@@ -1,13 +1,141 @@
+import { getInitials } from '@utils/getInitials'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 
-import styles from '../CommunityPage.module.scss'
+import { COMMUNITY_STATS_RANGES, HOME_URLS } from '@src/constants/constants'
+
+import commonStyles from '../CommunityPage.module.scss'
+import {
+  kpis,
+  trendExchanges,
+  trendNewBooks,
+  topContributors,
+  hotSearches,
+  activeHousesMapMock,
+} from '../mocks/communityStats.mock'
+
+import styles from './StatsTab.module.scss'
+
+type Range = (typeof COMMUNITY_STATS_RANGES)[number]
 
 export const StatsTab = () => {
   const { t } = useTranslation()
+  const [range, setRange] = useState<Range>(COMMUNITY_STATS_RANGES[0])
+
+  const rangeText = t('community.stats.filters.lastDays', { count: range })
+
+  const kpiItems = [
+    { key: 'exchanges', value: kpis.exchanges, icon: '🔄' },
+    { key: 'activeHouses', value: kpis.activeHouses, icon: '🏠' },
+    { key: 'activeUsers', value: kpis.activeUsers, icon: '👥' },
+    { key: 'booksPublished', value: kpis.booksPublished, icon: '📚' },
+  ] as const
+
   return (
-    <section className={styles.tabContent}>
-      <h2>{t('community.stats.title')}</h2>
-      <p>{t('community.stats.placeholder')}</p>
+    <section className={`${commonStyles.tabContent} ${styles.stats}`}>
+      <header className={styles.header}>
+        <h2>{t('community.stats.title')}</h2>
+        <p>{t('community.stats.subtitle')}</p>
+        <div
+          className={styles.filters}
+          role="group"
+          aria-label={t('community.stats.filters.aria')}
+        >
+          {COMMUNITY_STATS_RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              aria-pressed={range === r}
+              onClick={() => setRange(r)}
+            >
+              {t(`community.stats.filters.${r}d`)}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className={styles.kpiGrid}>
+        {kpiItems.map((item) => (
+          <div key={item.key} className={styles.kpiCard}>
+            <span aria-hidden="true" className={styles.icon}>
+              {item.icon}
+            </span>
+            <div className={styles.value}>{item.value.toLocaleString()}</div>
+            <div className={styles.label}>
+              {t(`community.stats.kpis.${item.key}`)}
+            </div>
+            <span className={styles.badge}>{rangeText}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.detailsGrid}>
+        <div className={styles.trendCard}>
+          <h3>{t('community.stats.trends.exchanges')}</h3>
+          <div className={styles.trendPlaceholder}>
+            {trendExchanges.map((h, idx) => (
+              <div key={`${h}-${idx}`} style={{ height: `${h}%` }} />
+            ))}
+          </div>
+        </div>
+        <div className={styles.trendCard}>
+          <h3>{t('community.stats.trends.newBooks')}</h3>
+          <div className={styles.trendPlaceholder}>
+            {trendNewBooks.map((h, idx) => (
+              <div key={`${h}-${idx}`} style={{ height: `${h}%` }} />
+            ))}
+          </div>
+        </div>
+        <div className={styles.topContributorsCard}>
+          <h3>{t('community.stats.topContributors.title')}</h3>
+          <ul aria-label="top-contributors">
+            {topContributors.map((user) => (
+              <li key={user.username}>
+                <span
+                  className={styles.avatar}
+                  role="img"
+                  aria-label={user.username}
+                >
+                  {getInitials(user.username)}
+                </span>
+                <span className={styles.name}>{user.username}</span>
+                <span className={styles.metric}>
+                  {t(`community.stats.topContributors.metric.${user.metric}`, {
+                    count: user.value,
+                  })}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <Link to={`/${HOME_URLS.COMMUNITY}`} className={styles.viewCommunity}>
+            {t('community.stats.topContributors.viewCommunity')}
+          </Link>
+        </div>
+        <div className={styles.mapCard}>
+          <h3>{t('community.stats.map.title')}</h3>
+          <div className={styles.mapPlaceholder}>
+            {activeHousesMapMock.map((pin) => (
+              <span
+                key={`${pin.top}-${pin.left}`}
+                className={styles.pin}
+                style={{ top: pin.top, left: pin.left }}
+              />
+            ))}
+          </div>
+          <p>{t('community.stats.map.description')}</p>
+        </div>
+        <div className={styles.hotSearchesCard}>
+          <h3>{t('community.stats.hotSearches.title')}</h3>
+          <div className={styles.chips}>
+            {hotSearches.map((item) => (
+              <span key={item.term} className={styles.chip}>
+                {item.term} ({item.count})
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/pages/community/tabs/events/EventCard.module.scss
+++ b/src/pages/community/tabs/events/EventCard.module.scss
@@ -1,0 +1,68 @@
+@import '@styles/variables';
+
+.card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-card);
+  border-radius: rem(12px);
+  overflow: hidden;
+  box-shadow: $box-shadow-sm;
+}
+
+.image {
+  width: 100%;
+  height: rem(140px);
+  object-fit: cover;
+}
+
+.content {
+  padding: $spacing-2;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+  flex: 1;
+}
+
+.title {
+  font-size: $h5-font-size;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.info {
+  font-size: $small-font-size;
+  color: var(--text-secondary);
+}
+
+.status {
+  width: fit-content;
+  font-size: $small-font-size;
+  padding: 0 $spacing-1;
+  border-radius: rem(4px);
+  font-weight: $font-weight-medium;
+
+  &.upcoming {
+    background-color: var(--color-success);
+    color: #fff;
+  }
+
+  &.past {
+    background-color: var(--color-error);
+    color: #fff;
+  }
+
+  &.ongoing {
+    background-color: var(--color-info);
+    color: #fff;
+  }
+}
+
+.detailsButton {
+  margin-top: auto;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: rem(8px);
+  padding: $spacing-1x5 $spacing-2;
+  cursor: pointer;
+}

--- a/src/pages/community/tabs/events/EventCard.tsx
+++ b/src/pages/community/tabs/events/EventCard.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+
+import { ApiEvent } from '@src/api/events/events.types'
+
+import styles from './EventCard.module.scss'
+
+interface Props {
+  event: ApiEvent
+}
+
+export const EventCard = ({ event }: Props) => {
+  const { t, i18n } = useTranslation()
+
+  const date = new Date(event.date)
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  }
+  const time = date.toLocaleTimeString(i18n.language, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+  const formattedDate = `${date.toLocaleDateString(
+    i18n.language,
+    dateOptions
+  )}, ${time}`
+
+  return (
+    <article className={styles.card}>
+      <img
+        src={event.imageUrl}
+        alt={t('community.events.image_alt', { title: event.title })}
+        className={styles.image}
+      />
+      <div className={styles.content}>
+        <h3 className={styles.title}>{event.title}</h3>
+        <p className={styles.info}>{formattedDate}</p>
+        <p className={styles.info}>{event.location}</p>
+        <p className={styles.info}>{event.description}</p>
+        <span className={`${styles.status} ${styles[event.status]}`}>
+          {t(`community.events.status.${event.status}`)}
+        </span>
+        <button className={styles.detailsButton}>
+          {t('community.events.details')}
+        </button>
+      </div>
+    </article>
+  )
+}

--- a/src/pages/community/tabs/events/EventsEmptyState.module.scss
+++ b/src/pages/community/tabs/events/EventsEmptyState.module.scss
@@ -1,0 +1,19 @@
+@import '@styles/variables';
+
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: $spacing-4 0;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  align-items: center;
+}
+
+.exploreButton {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: rem(8px);
+  padding: $spacing-1x5 $spacing-3;
+  cursor: pointer;
+}

--- a/src/pages/community/tabs/events/EventsEmptyState.tsx
+++ b/src/pages/community/tabs/events/EventsEmptyState.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import { EventStatus } from '@src/api/events/events.types'
+
+import styles from './EventsEmptyState.module.scss'
+
+interface Props {
+  status: EventStatus | 'all'
+}
+
+export const EventsEmptyState = ({ status }: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.empty}>
+      <p>{t(`community.events.empty.${status}`)}</p>
+      <Link to="/community" className={styles.exploreButton}>
+        {t('community.events.explore')}
+      </Link>
+    </div>
+  )
+}

--- a/src/pages/community/tabs/events/EventsFilters.module.scss
+++ b/src/pages/community/tabs/events/EventsFilters.module.scss
@@ -1,0 +1,25 @@
+@import '@styles/variables';
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+}
+
+.chip {
+  background: var(--background-card);
+  border: 1px solid var(--border-color);
+  border-radius: rem(16px);
+  padding: 0 $spacing-2;
+  height: rem(32px);
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.active {
+  background-color: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}

--- a/src/pages/community/tabs/events/EventsFilters.tsx
+++ b/src/pages/community/tabs/events/EventsFilters.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next'
+
+import { EventStatus } from '@src/api/events/events.types'
+
+import styles from './EventsFilters.module.scss'
+
+interface Props {
+  statusFilter: EventStatus | 'all'
+  onStatusChange: (status: EventStatus | 'all') => void
+  nearby: boolean
+  onToggleNearby: () => void
+}
+
+const statuses: (EventStatus | 'all')[] = ['upcoming', 'past', 'all']
+
+export const EventsFilters = ({
+  statusFilter,
+  onStatusChange,
+  nearby,
+  onToggleNearby,
+}: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.filters}>
+      {statuses.map((status) => (
+      <button
+        key={status}
+        className={`${styles.chip} ${statusFilter === status ? styles.active : ''}`}
+        aria-pressed={statusFilter === status}
+        onClick={() => onStatusChange(status)}
+      >
+        {t(`community.events.filters.status.${status}`)}
+      </button>
+      ))}
+      <button
+        className={`${styles.chip} ${nearby ? styles.active : ''}`}
+        aria-pressed={nearby}
+        onClick={onToggleNearby}
+      >
+        {t('community.events.filters.nearby')}
+      </button>
+    </div>
+  )
+}

--- a/src/pages/community/tabs/events/EventsMetrics.module.scss
+++ b/src/pages/community/tabs/events/EventsMetrics.module.scss
@@ -1,0 +1,27 @@
+@import '@styles/variables';
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  background-color: var(--background-card);
+  border-radius: rem(12px);
+  padding: $spacing-2;
+  box-shadow: $box-shadow-sm;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.metricNumber {
+  font-size: $h4-font-size;
+  color: var(--text-primary);
+}
+
+.metricLabel {
+  font-size: $small-font-size;
+  color: var(--text-secondary);
+}

--- a/src/pages/community/tabs/events/EventsMetrics.tsx
+++ b/src/pages/community/tabs/events/EventsMetrics.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next'
+
+import { ApiEventsMetrics } from '@src/api/events/events.types'
+
+import styles from './EventsMetrics.module.scss'
+
+interface Props {
+  metrics: ApiEventsMetrics
+}
+
+export const EventsMetrics = ({ metrics }: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.metric}>
+        <span className={styles.metricNumber}>{metrics.eventsThisMonth}</span>
+        <span className={styles.metricLabel}>
+          {t('community.events.metrics.events_this_month')}
+        </span>
+      </div>
+      <div className={styles.metric}>
+        <span className={styles.metricNumber}>{metrics.hostHouses}</span>
+        <span className={styles.metricLabel}>
+          {t('community.events.metrics.host_houses')}
+        </span>
+      </div>
+      <div className={styles.metric}>
+        <span className={styles.metricNumber}>{metrics.confirmedUsers}</span>
+        <span className={styles.metricLabel}>
+          {t('community.events.metrics.confirmed_users')}
+        </span>
+      </div>
+    </aside>
+  )
+}

--- a/src/utils/getInitials.ts
+++ b/src/utils/getInitials.ts
@@ -1,0 +1,2 @@
+export const getInitials = (username: string) =>
+  username.replace(/^@/, '').charAt(0).toUpperCase()

--- a/tests/pages/community/CommunityPage.test.tsx
+++ b/tests/pages/community/CommunityPage.test.tsx
@@ -37,9 +37,9 @@ describe('CommunityPage', () => {
       messages.getByText('community.messages.placeholder')
     ).toBeInTheDocument()
     const events = renderWithProviders(<EventsTab />)
-    expect(events.getByText('community.events.placeholder')).toBeInTheDocument()
+    expect(events.getByText('community.events.title')).toBeInTheDocument()
     const stats = renderWithProviders(<StatsTab />)
-    expect(stats.getByText('community.stats.placeholder')).toBeInTheDocument()
+    expect(stats.getByText('community.stats.subtitle')).toBeInTheDocument()
   })
 
   test('tab links use absolute paths', () => {

--- a/tests/pages/community/EventsTab.test.tsx
+++ b/tests/pages/community/EventsTab.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, test } from 'vitest'
+
+import events from '@mocks/handlers/events/fixtures/events.json'
+import { server } from '@mocks/server'
+import { EventsTab } from '@src/pages/community/tabs/EventsTab'
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import { renderWithProviders } from '../../test-utils'
+
+describe('EventsTab', () => {
+  test('renders list of events with mock data', async () => {
+    renderWithProviders(<EventsTab />)
+    expect(await screen.findByText('Club de lectura Borges')).toBeInTheDocument()
+    expect(await screen.findAllByRole('article')).toHaveLength(3)
+  })
+
+  test('changing filter shows past events', async () => {
+    renderWithProviders(<EventsTab />)
+    const pastButton = await screen.findByRole('button', {
+      name: 'community.events.filters.status.past',
+    })
+    fireEvent.click(pastButton)
+    expect(await screen.findByText('Presentación de autores locales')).toBeInTheDocument()
+    expect(screen.queryByText('Club de lectura Borges')).not.toBeInTheDocument()
+  })
+
+  test('shows empty state when no events match filter', async () => {
+    server.use(
+      http.get(RELATIVE_API_ROUTES.EVENTS.LIST, () =>
+        HttpResponse.json(events.filter((e) => e.status === 'upcoming'))
+      )
+    )
+    renderWithProviders(<EventsTab />)
+    const pastButton = await screen.findByRole('button', {
+      name: 'community.events.filters.status.past',
+    })
+    fireEvent.click(pastButton)
+    expect(await screen.findByText('community.events.empty.past')).toBeInTheDocument()
+  })
+
+  test('create event button is present', async () => {
+    const { getByRole } = renderWithProviders(<EventsTab />)
+    expect(getByRole('button', { name: 'community.events.create' })).toBeInTheDocument()
+  })
+})

--- a/tests/pages/community/StatsTab.test.tsx
+++ b/tests/pages/community/StatsTab.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, within } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { StatsTab } from '@src/pages/community/tabs/StatsTab'
+
+import { renderWithProviders } from '../../test-utils'
+
+describe('StatsTab', () => {
+  test('renders all sections', () => {
+    const { getByText, getByLabelText } = renderWithProviders(<StatsTab />)
+    expect(getByText('community.stats.title')).toBeInTheDocument()
+    expect(getByText('community.stats.subtitle')).toBeInTheDocument()
+    expect(getByText('community.stats.kpis.exchanges')).toBeInTheDocument()
+    expect(getByText('community.stats.kpis.activeHouses')).toBeInTheDocument()
+    expect(getByText('community.stats.kpis.activeUsers')).toBeInTheDocument()
+    expect(getByText('community.stats.kpis.booksPublished')).toBeInTheDocument()
+    expect(getByText('community.stats.trends.exchanges')).toBeInTheDocument()
+    expect(getByText('community.stats.trends.newBooks')).toBeInTheDocument()
+    expect(
+      getByText('community.stats.topContributors.title')
+    ).toBeInTheDocument()
+    const list = getByLabelText('top-contributors')
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5)
+    expect(getByText('community.stats.map.title')).toBeInTheDocument()
+    expect(getByText('community.stats.hotSearches.title')).toBeInTheDocument()
+  })
+
+  test('changes active range', () => {
+    const { getByText } = renderWithProviders(<StatsTab />)
+    const button = getByText('community.stats.filters.30d')
+    fireEvent.click(button)
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+  })
+})

--- a/tests/utils/getInitials.test.ts
+++ b/tests/utils/getInitials.test.ts
@@ -1,0 +1,9 @@
+import { getInitials } from '@utils/getInitials'
+import { describe, expect, test } from 'vitest'
+
+describe('getInitials', () => {
+  test('returns first letter without at sign', () => {
+    expect(getInitials('@gabriela')).toBe('G')
+    expect(getInitials('juan')).toBe('J')
+  })
+})


### PR DESCRIPTION
## Summary
- introduce events API routes, services, hooks, and MSW handlers
- split events tab into reusable subcomponents with improved styling
- update tests for events filtering and empty state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52632a640832ead366087b55a970e