### PR TITLE
Silence MSW unhandled request warnings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ async function enableMocking() {
     return
   }
   const { worker } = await import('@mocks/browser')
-  return worker.start()
+  return worker.start({ onUnhandledRequest: 'bypass' })
 }
 
 enableMocking().then(() => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -64,7 +64,7 @@ describe('index.tsx', () => {
       await import('@src/index')
     })
     expect(await screen.findByText('home.hero_title')).toBeTruthy()
-    expect(worker.start).toHaveBeenCalled()
+    expect(worker.start).toHaveBeenCalledWith({ onUnhandledRequest: 'bypass' })
 
     document.body.removeChild(rootElement)
     process.env.NODE_ENV = originalEnv

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -27,7 +27,7 @@ vi.mock('react-i18next', async () => {
   }
 })
 
-beforeAll(() => server.listen())
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
 
 // Clear cookies and reset handlers after each test to avoid cross-test contamination
 afterEach(() => {


### PR DESCRIPTION
## Summary
- start MSW worker with `onUnhandledRequest: 'bypass'`
- bypass unhandled requests in test server
- ensure worker is called with `onUnhandledRequest: 'bypass'` in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac12de24832eabc6f63a600eddc0