### PR TITLE
feat: add basic messaging page with chat API

### DIFF
--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -10,6 +10,10 @@ import { communityFeedHandler } from './community/feed.handler'
 import { suggestionsHandler } from './community/suggestions.handler'
 import { contactFormHandler } from './contactForm/contactForm.handler'
 import { userLanguageHandler } from './language/language.handler'
+import {
+  messagesListHandler,
+  messagesSendHandler,
+} from './messages/messages.handler'
 
 export const handlers = [
   loginHandler,
@@ -25,4 +29,6 @@ export const handlers = [
   communityFeedHandler,
   activityHandler,
   suggestionsHandler,
+  messagesListHandler,
+  messagesSendHandler,
 ]

--- a/mocks/handlers/messages/fakers/messages.faker.ts
+++ b/mocks/handlers/messages/fakers/messages.faker.ts
@@ -1,0 +1,16 @@
+import { Message } from '@src/api/messages/messages.types'
+
+export const generateMessages = (): Message[] => [
+  {
+    id: '1',
+    content: 'Hola!',
+    sender: 'other',
+    timestamp: new Date().toISOString(),
+  },
+  {
+    id: '2',
+    content: '¿Qué tal?',
+    sender: 'user',
+    timestamp: new Date().toISOString(),
+  },
+]

--- a/mocks/handlers/messages/messages.handler.ts
+++ b/mocks/handlers/messages/messages.handler.ts
@@ -1,0 +1,30 @@
+import { http, HttpResponse } from 'msw'
+
+import { Message } from '@src/api/messages/messages.types'
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import { generateMessages } from './fakers/messages.faker'
+
+let messages: Message[] = generateMessages()
+
+export const messagesListHandler = http.get(
+  RELATIVE_API_ROUTES.MESSAGES.LIST,
+  () => {
+    return HttpResponse.json(messages, { status: 200 })
+  }
+)
+
+export const messagesSendHandler = http.post(
+  RELATIVE_API_ROUTES.MESSAGES.LIST,
+  async ({ request }) => {
+    const { content } = (await request.json()) as { content: string }
+    const newMessage: Message = {
+      id: String(messages.length + 1),
+      content,
+      sender: 'user',
+      timestamp: new Date().toISOString(),
+    }
+    messages = [...messages, newMessage]
+    return HttpResponse.json(newMessage, { status: 201 })
+  }
+)

--- a/src/api/messages/messages.service.ts
+++ b/src/api/messages/messages.service.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@src/api/axios'
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import { Message } from './messages.types'
+
+export const fetchMessages = async (): Promise<Message[]> => {
+  const response = await apiClient.get<Message[]>(RELATIVE_API_ROUTES.MESSAGES.LIST)
+  if (!Array.isArray(response.data)) {
+    throw new Error('Invalid messages response')
+  }
+  return response.data
+}
+
+export const sendMessage = async (content: string): Promise<Message> => {
+  const response = await apiClient.post<Message>(
+    RELATIVE_API_ROUTES.MESSAGES.LIST,
+    { content }
+  )
+  return response.data
+}

--- a/src/api/messages/messages.types.ts
+++ b/src/api/messages/messages.types.ts
@@ -1,0 +1,6 @@
+export interface Message {
+  id: string
+  content: string
+  sender: 'user' | 'other'
+  timestamp: string
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -19,6 +19,9 @@ export const RELATIVE_API_ROUTES = {
     ACTIVITY: `/community/activity`,
     SUGGESTIONS: `/community/suggestions`,
   },
+  MESSAGES: {
+    LIST: `/messages`,
+  },
   LANGUAGE: {
     UPDATE: `/user/language`,
   },

--- a/src/components/community/MessagesTab.module.scss
+++ b/src/components/community/MessagesTab.module.scss
@@ -1,0 +1,46 @@
+.messagesSection {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.messagesList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  max-width: 70%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+}
+
+.user {
+  align-self: flex-end;
+  background-color: #d1e7dd;
+}
+
+.other {
+  align-self: flex-start;
+  background-color: #f8d7da;
+}
+
+.inputForm {
+  display: flex;
+  border-top: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.inputForm input {
+  flex: 1;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.inputForm button {
+  padding: 0.5rem 1rem;
+}

--- a/src/components/community/MessagesTab.tsx
+++ b/src/components/community/MessagesTab.tsx
@@ -1,13 +1,46 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import styles from './CommunityTabs.module.scss'
+import { useMessages } from '@src/hooks/api/useMessages'
+import { useSendMessage } from '@src/hooks/api/useSendMessage'
+
+import styles from './MessagesTab.module.scss'
 
 export const MessagesTab = () => {
   const { t } = useTranslation()
+  const { data: messages = [] } = useMessages()
+  const sendMessage = useSendMessage()
+  const [value, setValue] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (value.trim()) {
+      sendMessage.mutate(value)
+      setValue('')
+    }
+  }
+
   return (
-    <section className={styles.tabContent}>
+    <section className={styles.messagesSection}>
       <h2>{t('community.messages.title')}</h2>
-      <p>{t('community.messages.placeholder')}</p>
+      <div className={styles.messagesList}>
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`${styles.message} ${msg.sender === 'user' ? styles.user : styles.other}`}
+          >
+            {msg.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className={styles.inputForm}>
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={t('community.messages.input_placeholder')}
+        />
+        <button type="submit">{t('community.messages.send')}</button>
+      </form>
     </section>
   )
 }

--- a/src/hooks/api/useMessages.ts
+++ b/src/hooks/api/useMessages.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchMessages } from '@src/api/messages/messages.service'
+
+export const useMessages = () => {
+  return useQuery({ queryKey: ['messages'], queryFn: fetchMessages })
+}

--- a/src/hooks/api/useSendMessage.ts
+++ b/src/hooks/api/useSendMessage.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { sendMessage } from '@src/api/messages/messages.service'
+import { Message } from '@src/api/messages/messages.types'
+
+export const useSendMessage = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: sendMessage,
+    onSuccess: (message: Message) => {
+      queryClient.setQueryData<Message[]>(['messages'], (old) =>
+        old ? [...old, message] : [message]
+      )
+    },
+  })
+}

--- a/tests/pages/messages/MessagesPage.test.tsx
+++ b/tests/pages/messages/MessagesPage.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
 import { MessagesPage } from '@src/pages/messages/MessagesPage'
@@ -5,8 +6,16 @@ import { MessagesPage } from '@src/pages/messages/MessagesPage'
 import { renderWithProviders } from '../../test-utils'
 
 describe('MessagesPage', () => {
-  test('shows messages placeholder', () => {
-    const { getByText } = renderWithProviders(<MessagesPage />)
-    expect(getByText('community.messages.placeholder')).toBeInTheDocument()
+  test('loads and displays messages', async () => {
+    const { findByText } = renderWithProviders(<MessagesPage />)
+    expect(await findByText('Hola!')).toBeInTheDocument()
+  })
+
+  test('allows sending a message', async () => {
+    const { getByRole, findByText } = renderWithProviders(<MessagesPage />)
+    const input = getByRole('textbox') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Nuevo mensaje' } })
+    fireEvent.click(getByRole('button', { name: 'community.messages.send' }))
+    expect(await findByText('Nuevo mensaje')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- implement message API routes, services, hooks and MSW handlers
- create chat-style MessagesTab with send capability
- add tests for loading and sending messages

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run stylelint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b94b1dcc832e992d15dd309ecf27