### PR TITLE
feat: add Java backend skeleton with login endpoint

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,21 @@
+name: Backend CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: mvn -B test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 coverage/
 *.log
 npm-debug.log*
+backend/target/

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.entrelibros</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>EntreLibros Backend</name>
+    <description>Backend for EntreLibros</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/entrelibros/backend/BackendApplication.java
+++ b/backend/src/main/java/com/entrelibros/backend/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.entrelibros.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/AuthConfig.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/AuthConfig.java
@@ -1,0 +1,14 @@
+package com.entrelibros.backend.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/AuthController.java
@@ -1,0 +1,38 @@
+package com.entrelibros.backend.auth;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        try {
+            LoginResponse response = authService.login(request);
+            ResponseCookie cookie = ResponseCookie.from("sessionToken", response.token())
+                    .httpOnly(true)
+                    .path("/")
+                    .build();
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                    .body(response);
+        } catch (InvalidCredentialsException ex) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("InvalidCredentials", "auth.errors.invalid_credentials"));
+        }
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/AuthService.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/AuthService.java
@@ -1,0 +1,28 @@
+package com.entrelibros.backend.auth;
+
+import com.entrelibros.backend.user.User;
+import com.entrelibros.backend.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtService jwtService) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .filter(u -> passwordEncoder.matches(request.password(), u.password()))
+                .orElseThrow(InvalidCredentialsException::new);
+        String token = jwtService.generateToken(user);
+        UserDto dto = new UserDto(user.id(), user.email(), user.role());
+        return new LoginResponse(token, dto, "auth.success.login");
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/ErrorResponse.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/ErrorResponse.java
@@ -1,0 +1,3 @@
+package com.entrelibros.backend.auth;
+
+public record ErrorResponse(String error, String message) {}

--- a/backend/src/main/java/com/entrelibros/backend/auth/InvalidCredentialsException.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/InvalidCredentialsException.java
@@ -1,0 +1,4 @@
+package com.entrelibros.backend.auth;
+
+public class InvalidCredentialsException extends RuntimeException {
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/JwtService.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/JwtService.java
@@ -1,0 +1,36 @@
+package com.entrelibros.backend.auth;
+
+import com.entrelibros.backend.user.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private final SecretKey key;
+
+    public JwtService(@Value("${jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + Duration.ofHours(1).toMillis());
+        return Jwts.builder()
+                .setSubject(user.id())
+                .claim("email", user.email())
+                .claim("role", user.role())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/auth/LoginRequest.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.entrelibros.backend.auth;
+
+public record LoginRequest(String email, String password) {}

--- a/backend/src/main/java/com/entrelibros/backend/auth/LoginResponse.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.entrelibros.backend.auth;
+
+public record LoginResponse(String token, UserDto user, String message) {}

--- a/backend/src/main/java/com/entrelibros/backend/auth/UserDto.java
+++ b/backend/src/main/java/com/entrelibros/backend/auth/UserDto.java
@@ -1,0 +1,3 @@
+package com.entrelibros.backend.auth;
+
+public record UserDto(String id, String email, String role) {}

--- a/backend/src/main/java/com/entrelibros/backend/user/InMemoryUserRepository.java
+++ b/backend/src/main/java/com/entrelibros/backend/user/InMemoryUserRepository.java
@@ -1,0 +1,27 @@
+package com.entrelibros.backend.user;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryUserRepository implements UserRepository {
+
+    private final Map<String, User> users = new ConcurrentHashMap<>();
+
+    public InMemoryUserRepository(PasswordEncoder passwordEncoder) {
+        String email = "user@entrelibros.com";
+        String id = "1";
+        String role = "user";
+        String passwordHash = passwordEncoder.encode("correcthorsebatterystaple");
+        users.put(email, new User(id, email, passwordHash, role));
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return Optional.ofNullable(users.get(email));
+    }
+}

--- a/backend/src/main/java/com/entrelibros/backend/user/User.java
+++ b/backend/src/main/java/com/entrelibros/backend/user/User.java
@@ -1,0 +1,3 @@
+package com.entrelibros.backend.user;
+
+public record User(String id, String email, String password, String role) {}

--- a/backend/src/main/java/com/entrelibros/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/entrelibros/backend/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.entrelibros.backend.user;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+jwt.secret=change_me_please_very_secret_key_123456

--- a/backend/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -1,0 +1,37 @@
+package com.entrelibros.backend.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void loginWithValidCredentialsReturnsTokenAndCookie() {
+        LoginRequest request = new LoginRequest("user@entrelibros.com", "correcthorsebatterystaple");
+        ResponseEntity<LoginResponse> response = restTemplate.postForEntity("/auth/login", request, LoginResponse.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertNotNull(response.getBody().token());
+        assertTrue(response.getHeaders().containsKey(HttpHeaders.SET_COOKIE));
+    }
+
+    @Test
+    void loginWithInvalidCredentialsReturns401() {
+        LoginRequest request = new LoginRequest("user@entrelibros.com", "wrong");
+        ResponseEntity<ErrorResponse> response = restTemplate.postForEntity("/auth/login", request, ErrorResponse.class);
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("auth.errors.invalid_credentials", response.getBody().message());
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Spring Boot backend using Maven
- implement `/auth/login` with JWT and secure cookie
- add GitHub action for backend tests

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba0f2de8832e89bfa5c693bc8a92