### PR TITLE
chore: add docker build workflows and code checks

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -1,0 +1,24 @@
+name: Backend Docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/backend-docker.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/backend-docker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build backend Docker image
+        run: docker build -f backend/Dockerfile .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           sudo -u postgres createdb entrelibros_test
       - name: Install dependencies
         run: npm ci
-      - name: Run tests
+      - name: Run checks
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/entrelibros_test
           FRONTEND_URL: http://localhost:3000
-        run: npm test
+        run: npm run check

--- a/.github/workflows/frontend-docker.yml
+++ b/.github/workflows/frontend-docker.yml
@@ -1,0 +1,20 @@
+name: Frontend Docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-docker.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-docker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build frontend Docker image
+        run: docker build -f frontend/Dockerfile frontend

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm run lint:fix
+npm run format:fix

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm run typecheck
+npm test

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+npm-debug.log

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "endOfLine": "lf"
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY backend/package.json backend/
+RUN npm ci --workspace backend
+COPY backend ./backend
+RUN npm run build -w backend
+
+# Production stage
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY backend/package.json backend/
+RUN npm ci --omit=dev --workspace backend
+COPY --from=builder /app/backend/dist ./backend/dist
+CMD ["node", "backend/dist/index.js"]

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,29 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default [
+  {
+    ignores: ['dist'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        URL: 'readonly',
+      },
+    },
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+]

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,13 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "migrate": "node -r dotenv/config scripts/migrate.js",
-    "test": "cross-env-shell \"DOTENV_CONFIG_PATH=.env.test node -r dotenv/config scripts/migrate.js && node -r dotenv/config ../node_modules/vitest/vitest.mjs --run\""
+    "test": "cross-env-shell \"DOTENV_CONFIG_PATH=.env.test node -r dotenv/config scripts/migrate.js && node -r dotenv/config ../node_modules/vitest/vitest.mjs --run\"",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run lint && npm run format && npm run typecheck && npm test"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -27,10 +33,16 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.30",
     "@types/supertest": "^2.0.12",
+    "@types/morgan": "^1.9.7",
+    "@types/pg": "^8.10.2",
     "cross-env": "^7.0.3",
     "supertest": "^6.3.4",
     "tsx": "^4.7.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.0.7"
+    "vitest": "^3.0.7",
+    "@eslint/js": "^9.32.0",
+    "eslint": "^9.32.0",
+    "typescript-eslint": "^8.38.0",
+    "prettier": "^3.6.2"
   }
 }

--- a/backend/scripts/migrate.js
+++ b/backend/scripts/migrate.js
@@ -1,16 +1,20 @@
-import 'dotenv/config';
-import { migrate } from 'postgres-migrations';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import 'dotenv/config'
+import { migrate } from 'postgres-migrations'
+import { fileURLToPath } from 'url'
+import path from 'path'
 
-const connectionString = process.env.DATABASE_URL;
+const connectionString = process.env.DATABASE_URL
 if (!connectionString) {
-  console.error('DATABASE_URL is not set');
-  process.exit(1);
+  console.error('DATABASE_URL is not set')
+  process.exit(1)
 }
 
-const url = new URL(connectionString);
-const migrationsDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+const url = new URL(connectionString)
+const migrationsDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'migrations'
+)
 
 migrate(
   {
@@ -23,6 +27,6 @@ migrate(
   },
   migrationsDir
 ).catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+  console.error(err)
+  process.exit(1)
+})

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,11 +1,11 @@
-import request from 'supertest';
-import { describe, expect, it } from 'vitest';
-import app from './app.js';
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import app from './app.js'
 
 describe('GET /api/health', () => {
   it('returns ok status', async () => {
-    const res = await request(app).get('/api/health');
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
-  });
-});
+    const res = await request(app).get('/api/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'ok' })
+  })
+})

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,21 +1,21 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import morgan from 'morgan';
-import booksRouter from './routes/books.js';
+import express from 'express'
+import cors from 'cors'
+import helmet from 'helmet'
+import morgan from 'morgan'
+import booksRouter from './routes/books.js'
 
-const app = express();
+const app = express()
 
-app.use(helmet());
-const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-app.use(cors({ origin: frontendUrl }));
-app.use(express.json());
-app.use(morgan('dev'));
+app.use(helmet())
+const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000'
+app.use(cors({ origin: frontendUrl }))
+app.use(express.json())
+app.use(morgan('dev'))
 
 app.get('/api/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
+  res.json({ status: 'ok' })
+})
 
-app.use('/api/books', booksRouter);
+app.use('/api/books', booksRouter)
 
-export default app;
+export default app

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,24 +1,26 @@
-import { Pool, PoolClient } from 'pg';
+import { Pool, PoolClient, type QueryResult, type QueryResultRow } from 'pg'
 
-const connectionString = process.env.DATABASE_URL;
+const connectionString = process.env.DATABASE_URL
 if (!connectionString) {
-  throw new Error('DATABASE_URL is not set');
+  throw new Error('DATABASE_URL is not set')
 }
 
-export const pool = new Pool({ connectionString });
+export const pool = new Pool({ connectionString })
 
-let testClient: PoolClient | null = null;
+let testClient: PoolClient | null = null
 
 export function setTestClient(client: PoolClient | null) {
-  testClient = client;
+  testClient = client
 }
 
 export function getClient(): Pool | PoolClient {
-  return testClient ?? pool;
+  return testClient ?? pool
 }
 
-export async function query<T = any>(sql: string, params?: any[]): Promise<{ rows: T[] }> {
-  const client = getClient();
-  // Both Pool and PoolClient expose a compatible query method
-  return client.query(sql, params);
+export async function query<T extends QueryResultRow = QueryResultRow>(
+  sql: string,
+  params?: any[]
+): Promise<QueryResult<T>> {
+  const client = getClient()
+  return client.query<T>(sql, params)
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,16 +1,16 @@
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'url';
-import path from 'path';
+import dotenv from 'dotenv'
+import { fileURLToPath } from 'url'
+import path from 'path'
 
 const envFile = process.env.DOTENV_CONFIG_PATH
   ? path.resolve(process.cwd(), process.env.DOTENV_CONFIG_PATH)
-  : path.join(path.dirname(fileURLToPath(import.meta.url)), '../.env');
-dotenv.config({ path: envFile });
+  : path.join(path.dirname(fileURLToPath(import.meta.url)), '../.env')
+dotenv.config({ path: envFile })
 
-const { default: app } = await import('./app.js');
+const { default: app } = await import('./app.js')
 
-const PORT = process.env.PORT || 4000;
+const PORT = process.env.PORT || 4000
 
 app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+  console.log(`Server listening on port ${PORT}`)
+})

--- a/backend/src/repositories/bookRepository.test.ts
+++ b/backend/src/repositories/bookRepository.test.ts
@@ -1,27 +1,27 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
-import { pool, setTestClient } from '../db.js';
-import { createBook, listBooks } from './bookRepository.js';
-import type { PoolClient } from 'pg';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest'
+import { pool, setTestClient } from '../db.js'
+import { createBook, listBooks } from './bookRepository.js'
+import type { PoolClient } from 'pg'
 
-let client: PoolClient;
+let client: PoolClient
 
 beforeEach(async () => {
-  client = await pool.connect();
-  await client.query('BEGIN');
-  setTestClient(client);
-});
+  client = await pool.connect()
+  await client.query('BEGIN')
+  setTestClient(client)
+})
 
 afterEach(async () => {
-  await client.query('ROLLBACK');
-  client.release();
-  setTestClient(null);
-});
+  await client.query('ROLLBACK')
+  client.release()
+  setTestClient(null)
+})
 
 describe('bookRepository', () => {
   it('inserts and lists books', async () => {
-    await createBook('Test Book');
-    const books = await listBooks();
-    expect(books).toHaveLength(1);
-    expect(books[0].title).toBe('Test Book');
-  });
-});
+    await createBook('Test Book')
+    const books = await listBooks()
+    expect(books).toHaveLength(1)
+    expect(books[0].title).toBe('Test Book')
+  })
+})

--- a/backend/src/repositories/bookRepository.ts
+++ b/backend/src/repositories/bookRepository.ts
@@ -1,16 +1,19 @@
-import { query } from '../db.js';
+import { query } from '../db.js'
 
 export interface Book {
-  id: number;
-  title: string;
+  id: number
+  title: string
 }
 
 export async function createBook(title: string): Promise<Book> {
-  const { rows } = await query<Book>('INSERT INTO books (title) VALUES ($1) RETURNING *', [title]);
-  return rows[0];
+  const { rows } = await query<Book>(
+    'INSERT INTO books (title) VALUES ($1) RETURNING *',
+    [title]
+  )
+  return rows[0]
 }
 
 export async function listBooks(): Promise<Book[]> {
-  const { rows } = await query<Book>('SELECT * FROM books ORDER BY id');
-  return rows;
+  const { rows } = await query<Book>('SELECT * FROM books ORDER BY id')
+  return rows
 }

--- a/backend/src/routes/books.api.test.ts
+++ b/backend/src/routes/books.api.test.ts
@@ -1,28 +1,31 @@
-import request from 'supertest';
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
-import app from '../app.js';
-import { pool, setTestClient } from '../db.js';
-import type { PoolClient } from 'pg';
+import request from 'supertest'
+import { beforeEach, afterEach, describe, expect, it } from 'vitest'
+import app from '../app.js'
+import { pool, setTestClient } from '../db.js'
+import type { PoolClient } from 'pg'
 
-let client: PoolClient;
+let client: PoolClient
 
 beforeEach(async () => {
-  client = await pool.connect();
-  await client.query('BEGIN');
-  setTestClient(client);
-});
+  client = await pool.connect()
+  await client.query('BEGIN')
+  setTestClient(client)
+})
 
 afterEach(async () => {
-  await client.query('ROLLBACK');
-  client.release();
-  setTestClient(null);
-});
+  await client.query('ROLLBACK')
+  client.release()
+  setTestClient(null)
+})
 
 describe('books API', () => {
   it('creates and lists books via HTTP', async () => {
-    await request(app).post('/api/books').send({ title: 'API Book' }).expect(201);
-    const res = await request(app).get('/api/books').expect(200);
-    expect(res.body).toHaveLength(1);
-    expect(res.body[0].title).toBe('API Book');
-  });
-});
+    await request(app)
+      .post('/api/books')
+      .send({ title: 'API Book' })
+      .expect(201)
+    const res = await request(app).get('/api/books').expect(200)
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].title).toBe('API Book')
+  })
+})

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -1,20 +1,20 @@
-import { Router } from 'express';
-import { createBook, listBooks } from '../repositories/bookRepository.js';
+import { Router } from 'express'
+import { createBook, listBooks } from '../repositories/bookRepository.js'
 
-const router = Router();
+const router = Router()
 
 router.get('/', async (_req, res) => {
-  const books = await listBooks();
-  res.json(books);
-});
+  const books = await listBooks()
+  res.json(books)
+})
 
 router.post('/', async (req, res) => {
-  const { title } = req.body as { title?: string };
+  const { title } = req.body as { title?: string }
   if (!title) {
-    return res.status(400).json({ error: 'title is required' });
+    return res.status(400).json({ error: 'title is required' })
   }
-  const book = await createBook(title);
-  res.status(201).json(book);
-});
+  const book = await createBook(title)
+  res.status(201).json(book)
+})
 
-export default router;
+export default router

--- a/backend/src/utils/math.test.ts
+++ b/backend/src/utils/math.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { sum } from './math.js';
+import { describe, expect, it } from 'vitest'
+import { sum } from './math.js'
 
 describe('sum', () => {
   it('adds numbers without touching DB', () => {
-    expect(sum(2, 3)).toBe(5);
-  });
-});
+    expect(sum(2, 3)).toBe(5)
+  })
+})

--- a/backend/src/utils/math.ts
+++ b/backend/src/utils/math.ts
@@ -1,3 +1,3 @@
 export function sum(a: number, b: number): number {
-  return a + b;
+  return a + b
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "backend"
       ],
       "devDependencies": {
+        "husky": "^9.1.7",
         "npm-run-all": "^4.1.5"
       },
       "engines": {
@@ -29,14 +30,20 @@
         "postgres-migrations": "^5.3.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.32.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/morgan": "^1.9.7",
         "@types/node": "^20.11.30",
+        "@types/pg": "^8.10.2",
         "@types/supertest": "^2.0.12",
         "cross-env": "^7.0.3",
+        "eslint": "^9.32.0",
+        "prettier": "^3.6.2",
         "supertest": "^6.3.4",
         "tsx": "^4.7.0",
         "typescript": "^5.8.3",
+        "typescript-eslint": "^8.38.0",
         "vitest": "^3.0.7"
       },
       "engines": {
@@ -3163,6 +3170,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -3171,6 +3188,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -7153,6 +7182,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,17 @@
     "migrate": "npm run migrate -w backend",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "npm test -w backend",
-    "test:frontend": "npm test -w frontend"
+    "test:frontend": "npm test -w frontend",
+    "lint": "npm run lint -w backend && npm run lint -w frontend",
+    "lint:fix": "npm run lint:fix -w backend && npm run lint:fix -w frontend",
+    "format": "npm run format -w backend && npm run format -w frontend",
+    "format:fix": "npm run format:fix -w backend && npm run format:fix -w frontend",
+    "typecheck": "npm run typecheck -w backend && npm run typecheck -w frontend",
+    "check": "npm run format && npm run lint && npm run typecheck && npm test",
+    "prepare": "husky"
   },
   "devDependencies": {
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- build backend and frontend Docker images in dedicated workflows
- enforce linting, formatting, type checking and tests via CI and husky hooks
- add backend Dockerfile and eslint/prettier config

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4ab9dc70832e8d91e20460d8550f