### PR TITLE
ci: scope npm installs and restrict docker builds to main

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -31,10 +31,11 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      - run: npm ci --workspace backend
       - run: npm run format -w backend
       - run: npm run lint -w backend
       - run: npm run typecheck -w backend
       - run: npm run test -w backend
       - name: Build Docker image
+        if: github.ref == 'refs/heads/main'
         run: docker build -t backend -f backend/Dockerfile .

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,10 +15,11 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      - run: npm ci --workspace frontend
       - run: npm run format -w frontend
       - run: npm run lint -w frontend
       - run: npm run typecheck -w frontend
       - run: npm run test -w frontend
       - name: Build Docker image
+        if: github.ref == 'refs/heads/main'
         run: docker build -t frontend -f frontend/Dockerfile .


### PR DESCRIPTION
## Summary
- use workspace-specific npm installs in backend/frontend workflows
- only build Docker images on `main` to avoid unnecessary work

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c43768ab60832eb297ad97544cfd28