### PR TITLE
Add local PostGIS compose file and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,20 @@ El backend enviará una respuesta automática en el mismo canal usando el usuari
    - Copiar `backend/.env.example` a `backend/.env` y ajustar `DATABASE_URL`.
    - (Opcional) Copiar `backend/.env.test.example` a `backend/.env.test` para las pruebas. Este archivo se genera automáticamente si no existe.
    - Revisar `frontend/.env.example` para configurar el frontend.
-3. **Preparar base de datos y migraciones**
+3. **Levantar PostGIS con Docker**
+   ```bash
+   docker compose -f docker-compose.postgis.yml up -d
+   ```
+   Para detenerlo:
+   ```bash
+   docker compose -f docker-compose.postgis.yml down
+   ```
+4. **Preparar base de datos y migraciones**
    ```bash
    npm run migrate
    ```
    Crea la base definida en `backend/.env` y aplica las migraciones.
-4. **Levantar servidores**
+5. **Levantar servidores**
    ```bash
    npm run dev:backend   # backend
    npm run dev:frontend  # frontend

--- a/docker-compose.postgis.yml
+++ b/docker-compose.postgis.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: entrelibros
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -35,6 +35,7 @@ Resumen de Hechos (hasta la fecha)
 - Normalización/verificación de libros asistida por metadata/ISBN. [~]
 - Bases de trabajo: scripts de desarrollo y CI, documentación de entorno. [x]
 - Flujo de despliegue a Docker Hub para `main` y `dev`; plantillas `.env` con `JWT_SECRET`. [x]
+- PostGIS local con Docker Compose para desarrollo. [x]
 
 EP-1 Identidad y Perfil
 Feature 1.1 Cuenta y acceso


### PR DESCRIPTION
## Summary
- add docker-compose setup for local PostGIS
- document how to start and stop the database
- note the new compose option in the backlog

## Testing
- `npm run lint -w backend`
- `npm run format -w backend`
- `npm run typecheck -w backend`
- `npm run test:backend` *(fails: connect ECONNREFUSED ::1:5432)*
- `npm run lint -w frontend`
- `npm run format -w frontend`
- `npm run typecheck -w frontend`
- `npm run test:frontend`
- `npm run format:backend`
- `npm run format:frontend`


------
https://chatgpt.com/codex/tasks/task_e_68c6d830a808832e8827641fde253d6e