### PR TITLE
Implement agreement chat bubble mocks

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -121,10 +121,16 @@ Feature 5.1 Mensajería 1:1
 
 Feature 5.2 Acuerdos
 
-- [ ] S-5.3 Confirmación de acuerdo (lugar RdL/espacio público, horario) (Must, E1; BR-41)
+- [~] S-5.3 Confirmación de acuerdo (lugar RdL/espacio público, horario) (Must, E1; BR-41)
   - Éxito: registra acuerdo y dispara recordatorio.
-- [ ] S-5.4 Registro post-encuentro (“se concretó / no se concretó”) (Should, E2; BR-42)
+  - Actualización: la UI de mensajería muestra burbujas específicas (propuesta, confirmación, recordatorios, reprogramación y cancelación) con dataset mock y accesibilidad/i18n completa; resta conectar con backend y persistencia real.
+- [ ] S-5.3a Automatizar confirmación y recordatorios (backend + notificaciones) (Must, E1; BR-41)
+  - Éxito: persistencia del acuerdo, disparo de recordatorios reales y actualización de estado en socket/notificaciones.
+- [~] S-5.4 Registro post-encuentro (“se concretó / no se concretó”) (Should, E2; BR-42)
   - Éxito: alimenta métricas sin exponer datos personales.
+  - Actualización: se agregó la tarjeta de seguimiento post-encuentro con acciones Sí/No dentro del chat; falta registrar la respuesta en backend y alimentar métricas.
+- [ ] S-5.4a Persistir resultados post-encuentro y métricas (Should, E2; BR-42)
+  - Éxito: almacenar la respuesta de cierre, actualizar indicadores y exponerlos a coordinación.
 
 Feature 5.3 Notificaciones
 

--- a/docs/messaging-flow.md
+++ b/docs/messaging-flow.md
@@ -1,0 +1,54 @@
+# Flujo de mensajería orientado a acuerdos
+
+Este documento resume el flujo conversacional diseñado para coordinar intercambios de libros dentro del chat 1:1 de EntreLibros. El objetivo es reducir la fricción al cerrar acuerdos, mantener la privacidad (solo barrio/ciudad) y asegurar que todas las acciones relevantes ocurran dentro del mismo hilo.
+
+## Tipos de burbuja
+
+Cada mensaje se construye a partir del componente `BubbleBase`, que garantiza alineación por rol (yo/otra persona/sistema), tonos accesibles en temas claro/oscuro y uso de los tokens cromáticos existentes.
+
+| Tipo de burbuja | Uso | Contenido principal | Acciones |
+| --- | --- | --- | --- |
+| **Texto libre / Plantilla** | Conversación inicial o aclaraciones. | Mensaje plano, puede indicar si proviene de una plantilla. | — |
+| **Propuesta de acuerdo** | Enviar lugar (Rincón de Libros o espacio público), barrio/ciudad, horario y libro. | Tarjeta estructurada con los tres datos clave. | `Confirmar` y `Proponer cambio`. |
+| **Confirmación de acuerdo** | Aceptar una propuesta. | Sello "Confirmado por…" + detalles del acuerdo vigente. | — |
+| **Recordatorio automático** | Avisos programados antes del encuentro (día anterior y mismo día). | Mensaje informativo + resumen del acuerdo vigente. | — |
+| **Reprogramación** | Sugerir un nuevo horario/lugar conservando el contexto previo. | Nota del remitente, detalles originales y propuesta nueva. | `Aceptar` y `Sugerir otro`. |
+| **Cancelación** | Cancelar el acuerdo con un motivo breve. | Motivo y referencia al acuerdo cancelado. | — |
+| **Seguimiento post-encuentro** | Preguntar si se concretó el intercambio. | Pregunta del sistema + botones `Sí`/`No` y recordatorio de los datos. | `Sí` y `No`. |
+| **Consejo de seguridad** | Primer recordatorio de buenas prácticas. | Recomendación para reunirse en espacio público o Rincón de Libros. | — |
+
+## Comportamientos clave del flujo
+
+1. **Inicio rápido**: la conversación puede comenzar con texto libre o a través del botón de plantillas que inyecta atajos traducibles (interés, disponibilidad, propuesta de lugar).
+2. **Ciclo del acuerdo**: Propuesta → Confirmación → Recordatorios → Seguimiento post-encuentro. Todos los pasos quedan visibles en el hilo.
+3. **Gestión de cambios**:
+   - **Reprogramar**: muestra contexto del acuerdo original y la propuesta nueva; al confirmarse, reemplaza la versión anterior sin borrar el historial.
+   - **Cancelar**: notifica el motivo y deja el historial listo para proponer otro encuentro.
+4. **Automatismos del sistema**: consejos de seguridad, recordatorios y seguimiento se originan con rol `system`, centrados en el hilo y diferenciados por tono.
+5. **Privacidad por diseño**: solo se muestran el nombre del espacio (Rincón de Libros o lugar público) y el barrio/ciudad. Nunca se pide ni se expone dirección exacta ni datos personales.
+
+## Buenas prácticas de tono y accesibilidad
+
+- Mensajes claros, neutrales y corteses. Se evita lenguaje agresivo o ambiguo.
+- Contraste adecuado en ambos temas gracias a los tonos `primary`, `secondary`, `success`, `info`, `warning` y `neutral` definidos en el wrapper.
+- Etiquetas y botones traducibles (ES/EN) mediante `common.community.messages.chat.*`.
+- `BubbleBase` incorpora roles accesibles (`role="group"`) y variantes pensadas para lectores de pantalla.
+
+## Dataset de conversación mock
+
+`frontend/src/components/messages/Messages.mock.ts` contiene tres conversaciones fijas:
+
+- **Flujo feliz completo** (Samuel): cubre desde plantilla inicial hasta seguimiento post-encuentro, con recordatorios automáticos y reprogramación.
+- **Propuesta pendiente** (Laura): ejemplo de negociación en curso, con reprogramación manual antes de confirmar.
+- **Acuerdo cancelado** (Pablo): incluye recordatorio y cancelación con motivo para mantener el historial claro.
+
+Estas conversaciones se usan en la UI mock para validar visualmente todos los estados requeridos.
+
+## Referencias técnicas
+
+- Componentes de burbuja en `frontend/src/components/messages/bubbles/`.
+- Wrapper genérico: `BubbleBase` maneja alineación, tonos, acciones y meta-información.
+- Estilos compartidos: `BubbleBase.module.scss`, `BubbleContent.module.scss` y `Messages.module.scss`.
+- Traducciones: `common.community.messages.chat` (ES/EN).
+
+Mantener este documento actualizado al agregar nuevas variantes garantiza coherencia entre producto, diseño y desarrollo.

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.5'
-const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const PACKAGE_VERSION = '2.11.3'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -71,11 +71,6 @@ addEventListener('message', async function (event) {
       break
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
-    }
-
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
@@ -94,6 +89,8 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
     return
@@ -110,23 +107,29 @@ addEventListener('fetch', function (event) {
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
-  // after it's been deleted (still remains active until the next reload).
+  // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
     return
   }
 
   const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
 })
 
 /**
  * @param {FetchEvent} event
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  */
-async function handleRequest(event, requestId) {
+async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -204,7 +207,7 @@ async function resolveMainClient(event) {
  * @param {string} requestId
  * @returns {Promise<Response>}
  */
-async function getResponse(event, client, requestId) {
+async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
   const requestClone = event.request.clone()
@@ -255,6 +258,7 @@ async function getResponse(event, client, requestId) {
       type: 'REQUEST',
       payload: {
         id: requestId,
+        interceptedAt: requestInterceptedAt,
         ...serializedRequest,
       },
     },

--- a/frontend/src/assets/i18n/locales/en/common.json
+++ b/frontend/src/assets/i18n/locales/en/common.json
@@ -144,7 +144,101 @@
     },
     "messages": {
       "title": "Messages",
-      "placeholder": "Messages list"
+      "placeholder": "Messages list",
+      "chat": {
+        "searchPlaceholder": "Search conversations",
+        "searchAria": "Search conversations",
+        "offline": "Offline",
+        "offlineWithError": "Offline: {{error}}",
+        "emptyState": "Select a conversation to start",
+        "inputPlaceholder": "Type a message...",
+        "templateButton": "Templates",
+        "status": {
+          "online": "Online",
+          "lastSeen": "Last seen {{value}}"
+        },
+        "actions": {
+          "profile": "View participant info",
+          "attach": "Attach file",
+          "emoji": "Open emojis",
+          "send": "Send message",
+          "confirm": "Confirm",
+          "proposeChange": "Propose change",
+          "accept": "Accept proposal",
+          "suggestAnother": "Suggest another time",
+          "yes": "Yes",
+          "no": "No"
+        },
+        "templates": {
+          "interest": {
+            "label": "Interest in a book",
+            "text": "Hi! I'm interested in this book. Is it still available for exchange?"
+          },
+          "availability": {
+            "label": "Check availability",
+            "text": "When works for you? I can meet this week."
+          },
+          "place": {
+            "label": "Suggest meeting spot",
+            "text": "Could we meet at a Book Nook or another public place in the neighbourhood?"
+          }
+        },
+        "labels": {
+          "template": "Template",
+          "proposal": "Agreement proposal",
+          "confirmation": "Agreement confirmed",
+          "reminder": "Reminder",
+          "reschedule": "Reschedule",
+          "cancellation": "Agreement cancelled",
+          "postMeeting": "Post-meeting check-in",
+          "tip": "Safety tip"
+        },
+        "a11y": {
+          "proposal": "Agreement proposal card",
+          "confirmation": "Agreement confirmation card",
+          "reminder": "Agreement reminder",
+          "reschedule": "Reschedule card",
+          "cancellation": "Cancellation notice",
+          "postMeeting": "Post-meeting follow-up",
+          "tip": "Safety tip"
+        },
+        "badges": {
+          "proposalPending": "Proposal pending",
+          "agreementConfirmed": "Agreement confirmed",
+          "reminderScheduled": "Reminder scheduled",
+          "awaitingFeedback": "Awaiting follow-up",
+          "cancelled": "Cancelled"
+        },
+        "snippets": {
+          "proposal": "Proposal: {{book}}",
+          "confirmation": "Confirmed: {{book}}",
+          "reminder": "Reminder {{time}}",
+          "reschedule": "Reschedule suggested",
+          "cancellation": "Agreement cancelled",
+          "postMeeting": "Post-meeting check-in",
+          "tip": "Safety tip"
+        },
+        "location": {
+          "bookCorner": "Book Nook",
+          "publicSpace": "Public space"
+        },
+        "fields": {
+          "place": "Place",
+          "schedule": "Date & time",
+          "book": "Book"
+        },
+        "confirmedBy": "Confirmed by {{name}}",
+        "reschedule": {
+          "previous": "Original agreement",
+          "proposed": "New proposal"
+        },
+        "cancellation": {
+          "reason": "Reason: {{reason}}"
+        },
+        "postCheck": {
+          "note": "Your answer helps keep our community trustworthy."
+        }
+      }
     },
     "events": {
       "title": "Events",

--- a/frontend/src/assets/i18n/locales/es/common.json
+++ b/frontend/src/assets/i18n/locales/es/common.json
@@ -144,7 +144,101 @@
     },
     "messages": {
       "title": "Mensajes",
-      "placeholder": "Lista de mensajes"
+      "placeholder": "Lista de mensajes",
+      "chat": {
+        "searchPlaceholder": "Buscar conversaciones",
+        "searchAria": "Buscar conversaciones",
+        "offline": "Sin conexión",
+        "offlineWithError": "Sin conexión: {{error}}",
+        "emptyState": "Selecciona una conversación para iniciar",
+        "inputPlaceholder": "Escribe un mensaje...",
+        "templateButton": "Plantillas",
+        "status": {
+          "online": "En línea",
+          "lastSeen": "Visto {{value}}"
+        },
+        "actions": {
+          "profile": "Ver detalles de la persona",
+          "attach": "Adjuntar archivo",
+          "emoji": "Abrir emojis",
+          "send": "Enviar mensaje",
+          "confirm": "Confirmar",
+          "proposeChange": "Proponer cambio",
+          "accept": "Aceptar propuesta",
+          "suggestAnother": "Sugerir otro horario",
+          "yes": "Sí",
+          "no": "No"
+        },
+        "templates": {
+          "interest": {
+            "label": "Interés por un libro",
+            "text": "Hola, me interesa este libro. ¿Sigue en intercambio?"
+          },
+          "availability": {
+            "label": "Consultar disponibilidad",
+            "text": "¿Cuándo te viene bien encontrarnos? Tengo disponibilidad esta semana."
+          },
+          "place": {
+            "label": "Proponer punto de encuentro",
+            "text": "¿Te parece si nos vemos en un Rincón de Libros o espacio público cerca del barrio?"
+          }
+        },
+        "labels": {
+          "template": "Plantilla",
+          "proposal": "Propuesta de acuerdo",
+          "confirmation": "Acuerdo confirmado",
+          "reminder": "Recordatorio",
+          "reschedule": "Reprogramación",
+          "cancellation": "Acuerdo cancelado",
+          "postMeeting": "Seguimiento del encuentro",
+          "tip": "Consejo de seguridad"
+        },
+        "a11y": {
+          "proposal": "Tarjeta de propuesta de acuerdo",
+          "confirmation": "Tarjeta de confirmación de acuerdo",
+          "reminder": "Recordatorio del acuerdo",
+          "reschedule": "Tarjeta de reprogramación",
+          "cancellation": "Aviso de cancelación",
+          "postMeeting": "Seguimiento posterior al encuentro",
+          "tip": "Consejo de seguridad"
+        },
+        "badges": {
+          "proposalPending": "Propuesta pendiente",
+          "agreementConfirmed": "Acuerdo confirmado",
+          "reminderScheduled": "Recordatorio activo",
+          "awaitingFeedback": "Esperando cierre",
+          "cancelled": "Cancelado"
+        },
+        "snippets": {
+          "proposal": "Propuesta: {{book}}",
+          "confirmation": "Confirmado: {{book}}",
+          "reminder": "Recordatorio {{time}}",
+          "reschedule": "Reprogramación sugerida",
+          "cancellation": "Acuerdo cancelado",
+          "postMeeting": "Seguimiento post-encuentro",
+          "tip": "Consejo de seguridad"
+        },
+        "location": {
+          "bookCorner": "Rincón de Libros",
+          "publicSpace": "Espacio público"
+        },
+        "fields": {
+          "place": "Lugar",
+          "schedule": "Día y hora",
+          "book": "Libro"
+        },
+        "confirmedBy": "Confirmado por {{name}}",
+        "reschedule": {
+          "previous": "Acuerdo original",
+          "proposed": "Nueva propuesta"
+        },
+        "cancellation": {
+          "reason": "Motivo: {{reason}}"
+        },
+        "postCheck": {
+          "note": "Tu respuesta ayuda a mantener la confianza en la comunidad."
+        }
+      }
     },
     "events": {
       "title": "Eventos",

--- a/frontend/src/components/messages/Messages.mock.ts
+++ b/frontend/src/components/messages/Messages.mock.ts
@@ -1,113 +1,310 @@
 import { Conversation } from '@components/messages/Messages.types'
 
+const baseAgreement = {
+  location: {
+    name: 'Rincón Parque Central',
+    area: 'Nervión, Sevilla',
+    type: 'bookCorner' as const,
+  },
+  schedule: {
+    day: 'Martes 4 de marzo',
+    time: '19:00',
+  },
+  book: {
+    title: 'El nombre del viento',
+  },
+}
+
+const updatedAgreement = {
+  ...baseAgreement,
+  schedule: {
+    day: 'Martes 4 de marzo',
+    time: '19:30',
+  },
+}
+
 export const mockConversations: Conversation[] = [
   {
-    id: 0,
-    user: {
-      name: 'Bot',
-      avatar: 'https://i.pravatar.cc/40?u=bot',
-      online: true,
-    },
-    badges: [],
-    messages: [],
-  },
-  {
     id: 1,
+    channel: 'Samuel',
     user: {
       name: 'Samuel',
-      avatar: 'https://i.pravatar.cc/40?img=1',
+      avatar: 'https://i.pravatar.cc/96?img=5',
       online: true,
     },
-    badges: ['book'],
+    badges: ['agreementConfirmed', 'awaitingFeedback'],
     messages: [
       {
-        id: 1,
-        sender: 'them',
-        text: "I'll trade it for your book",
-        time: '4:30 PM',
+        id: '1',
+        role: 'me',
+        type: 'template',
+        text: 'Hola, me interesa El nombre del viento. ¿Sigue en intercambio?',
+        templateLabel: 'Plantilla: interés por título',
+        createdAt: '2025-03-01T17:02:00.000Z',
+        displayTime: '17:02',
       },
       {
-        id: 2,
-        sender: 'me',
-        text: "Hi! I'm interested in To Kill a Mockingbird",
-        time: '4:32 PM',
+        id: '2',
+        role: 'them',
+        type: 'text',
+        text: 'Sí, perfecto. Lo tengo listo para intercambio.',
+        createdAt: '2025-03-01T17:04:00.000Z',
+        displayTime: '17:04',
       },
       {
-        id: 3,
-        sender: 'them',
-        text: 'Sure! Are you offering a book for exchange?',
-        time: '4:35 PM',
+        id: '3',
+        role: 'me',
+        type: 'proposal',
+        proposal: baseAgreement,
+        createdAt: '2025-03-01T17:06:00.000Z',
+        displayTime: '17:06',
       },
       {
-        id: 4,
-        sender: 'me',
-        text: "I'll trade it for your book",
-        book: {
-          title: 'The Wind-Up Bird Chronicle',
-          author: 'Haruki Murakami',
-          cover: 'https://covers.openlibrary.org/b/id/240726-S.jpg',
+        id: '4',
+        role: 'system',
+        type: 'safety-tip',
+        tip: 'Reúnete en un espacio público o un Rincón de Libros. Avisa a alguien de confianza.',
+        createdAt: '2025-03-01T17:06:30.000Z',
+        displayTime: '17:06',
+      },
+      {
+        id: '5',
+        role: 'them',
+        type: 'confirmation',
+        confirmation: {
+          ...baseAgreement,
+          confirmedBy: 'Samuel',
         },
-        time: '4:37 PM',
+        createdAt: '2025-03-01T17:08:00.000Z',
+        displayTime: '17:08',
       },
       {
-        id: 5,
-        sender: 'them',
-        text: 'Sounds good!',
-        time: '4:37 PM',
+        id: '6',
+        role: 'system',
+        type: 'reminder',
+        reminder: {
+          message:
+            'Mañana 19:00 en Rincón Parque Central (Nervión) por El nombre del viento.',
+          details: baseAgreement,
+        },
+        createdAt: '2025-03-03T19:00:00.000Z',
+        displayTime: '19:00',
+      },
+      {
+        id: '7',
+        role: 'system',
+        type: 'reminder',
+        reminder: {
+          message:
+            'Hoy 19:00 en Rincón Parque Central (Nervión) por El nombre del viento.',
+          details: baseAgreement,
+        },
+        createdAt: '2025-03-04T10:00:00.000Z',
+        displayTime: '10:00',
+      },
+      {
+        id: '8',
+        role: 'me',
+        type: 'reschedule',
+        reschedule: {
+          note: '¿19:30 mismo lugar? Salgo de una reunión a esa hora.',
+          previous: baseAgreement,
+          proposed: {
+            schedule: updatedAgreement.schedule,
+          },
+        },
+        createdAt: '2025-03-04T12:10:00.000Z',
+        displayTime: '12:10',
+      },
+      {
+        id: '9',
+        role: 'them',
+        type: 'confirmation',
+        confirmation: {
+          ...updatedAgreement,
+          confirmedBy: 'Samuel',
+        },
+        createdAt: '2025-03-04T12:14:00.000Z',
+        displayTime: '12:14',
+      },
+      {
+        id: '10',
+        role: 'system',
+        type: 'post-check',
+        question: '¿Se concretó el intercambio?',
+        details: updatedAgreement,
+        createdAt: '2025-03-04T21:00:00.000Z',
+        displayTime: '21:00',
+      },
+      {
+        id: '11',
+        role: 'me',
+        type: 'text',
+        text: 'Sí, gracias por coordinar. ¡Nos vemos en el próximo intercambio!',
+        createdAt: '2025-03-05T08:00:00.000Z',
+        displayTime: '08:00',
       },
     ],
   },
   {
     id: 2,
+    channel: 'Laura',
     user: {
       name: 'Laura',
-      avatar: 'https://i.pravatar.cc/40?img=2',
+      avatar: 'https://i.pravatar.cc/96?img=12',
       online: false,
-      lastSeen: '2h ago',
+      lastSeen: 'Hace 2 h',
     },
-    badges: ['unread'],
+    badges: ['proposalPending'],
     messages: [
       {
-        id: 1,
-        sender: 'them',
-        text: 'Great, thanks!',
-        time: '1:15 PM',
+        id: '1',
+        role: 'them',
+        type: 'text',
+        text: 'Hola, vi que buscas El infinito en un junco. ¿Te interesa coordinar?',
+        createdAt: '2025-02-26T15:00:00.000Z',
+        displayTime: '15:00',
+      },
+      {
+        id: '2',
+        role: 'me',
+        type: 'text',
+        text: 'Sí, me encanta. ¿Qué día te sirve?',
+        createdAt: '2025-02-26T15:02:00.000Z',
+        displayTime: '15:02',
+      },
+      {
+        id: '3',
+        role: 'them',
+        type: 'proposal',
+        proposal: {
+          location: {
+            name: 'Biblioteca Popular San Martín',
+            area: 'Caballito, Buenos Aires',
+            type: 'public',
+          },
+          schedule: {
+            day: 'Jueves 27 de febrero',
+            time: '18:30',
+          },
+          book: {
+            title: 'El infinito en un junco',
+          },
+        },
+        createdAt: '2025-02-26T15:05:00.000Z',
+        displayTime: '15:05',
+      },
+      {
+        id: '4',
+        role: 'me',
+        type: 'reschedule',
+        reschedule: {
+          note: 'Salgo 18:15 del trabajo, ¿podemos pasarla a las 19:00?',
+          previous: {
+            location: {
+              name: 'Biblioteca Popular San Martín',
+              area: 'Caballito, Buenos Aires',
+              type: 'public',
+            },
+            schedule: {
+              day: 'Jueves 27 de febrero',
+              time: '18:30',
+            },
+            book: { title: 'El infinito en un junco' },
+          },
+          proposed: {
+            schedule: {
+              day: 'Jueves 27 de febrero',
+              time: '19:00',
+            },
+            location: {
+              name: 'Biblioteca Popular San Martín',
+              area: 'Caballito, Buenos Aires',
+              type: 'public',
+            },
+          },
+        },
+        createdAt: '2025-02-26T15:08:00.000Z',
+        displayTime: '15:08',
       },
     ],
   },
   {
     id: 3,
+    channel: 'Pablo',
     user: {
       name: 'Pablo',
-      avatar: 'https://i.pravatar.cc/40?img=3',
+      avatar: 'https://i.pravatar.cc/96?img=23',
       online: false,
-      lastSeen: '5m ago',
+      lastSeen: 'Conectado hace 5 minutos',
     },
-    badges: ['swap'],
+    badges: ['cancelled'],
     messages: [
       {
-        id: 1,
-        sender: 'them',
-        text: 'Swap request pending',
-        time: 'Yesterday',
+        id: '1',
+        role: 'me',
+        type: 'text',
+        text: '¡Gracias por confirmar el intercambio de Rayuela!',
+        createdAt: '2025-02-20T10:00:00.000Z',
+        displayTime: '10:00',
       },
-    ],
-  },
-  {
-    id: 4,
-    user: {
-      name: 'Sophia',
-      avatar: 'https://i.pravatar.cc/40?img=4',
-      online: false,
-      lastSeen: 'online',
-    },
-    badges: [],
-    messages: [
       {
-        id: 1,
-        sender: 'them',
-        text: 'Whoa, sounds like a great book!',
-        time: 'Yesterday',
+        id: '2',
+        role: 'system',
+        type: 'reminder',
+        reminder: {
+          message:
+            'Recordatorio: hoy 18:00 en Plaza Dorrego (San Telmo) por Rayuela.',
+          details: {
+            location: {
+              name: 'Plaza Dorrego',
+              area: 'San Telmo, Buenos Aires',
+              type: 'public',
+            },
+            schedule: {
+              day: 'Viernes 21 de febrero',
+              time: '18:00',
+            },
+            book: {
+              title: 'Rayuela',
+            },
+          },
+        },
+        createdAt: '2025-02-21T08:00:00.000Z',
+        displayTime: '08:00',
+      },
+      {
+        id: '3',
+        role: 'them',
+        type: 'cancellation',
+        cancellation: {
+          reason:
+            'Se me complicó llegar hoy, podemos reintentarlo la semana próxima.',
+          details: {
+            location: {
+              name: 'Plaza Dorrego',
+              area: 'San Telmo, Buenos Aires',
+              type: 'public',
+            },
+            schedule: {
+              day: 'Viernes 21 de febrero',
+              time: '18:00',
+            },
+            book: {
+              title: 'Rayuela',
+            },
+          },
+        },
+        createdAt: '2025-02-21T12:00:00.000Z',
+        displayTime: '12:00',
+      },
+      {
+        id: '4',
+        role: 'system',
+        type: 'text',
+        text: 'El acuerdo quedó cancelado. Puedes enviar una nueva propuesta cuando quieras.',
+        createdAt: '2025-02-21T12:01:00.000Z',
+        displayTime: '12:01',
       },
     ],
   },

--- a/frontend/src/components/messages/Messages.module.scss
+++ b/frontend/src/components/messages/Messages.module.scss
@@ -23,16 +23,20 @@
 }
 
 .sidebarHeader {
-  padding: $spacing-2;
+  padding: $spacing-3;
   border-bottom: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
 }
 
 .search {
-  width: calc(100% - $spacing-4);
+  width: 100%;
   border: 1px solid var(--border-color);
   background: var(--background-card);
   color: var(--text-primary);
-  margin-top: rem(25px);
+  border-radius: rem(12px);
+  padding: $spacing-2 $spacing-3;
 }
 
 .conversationList {
@@ -51,28 +55,34 @@
 
 .conversationItem {
   display: flex;
-  gap: $spacing-1;
-  padding: $spacing-1;
+  gap: $spacing-2;
+  padding: $spacing-2;
   align-items: center;
   cursor: pointer;
   border: 0;
   border-radius: rem(14px);
-  margin: rem(5px) rem(10px);
-  transition: background 0.2s ease;
+  margin: rem(6px);
+  transition: background $transition-duration-fast ease;
 
   &:hover {
-    background: color-mix(in srgb, var(--background-card) 92%, #000 8%);
+    background: color-mix(in srgb, var(--background-card) 90%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+    outline-offset: 2px;
   }
 }
 
 .conversationItemActive {
-  background: color-mix(in srgb, var(--background-card) 88%, #000 12%);
-  box-shadow: inset 0 0 0 1px var(--border-color);
+  background: color-mix(in srgb, var(--background-card) 85%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--primary-color) 35%, transparent);
 }
 
 .avatar {
-  width: rem(40px);
-  height: rem(40px);
+  width: rem(42px);
+  height: rem(42px);
   border-radius: 50%;
   object-fit: cover;
 }
@@ -81,6 +91,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 2px;
 }
 
 .name {
@@ -90,33 +101,77 @@
 .snippet {
   font-size: $small-font-size;
   color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .badges {
   display: flex;
   gap: $spacing-1;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .badge {
-  background: var(--primary-color);
-  color: #fff;
-  padding: 2px 8px;
+  padding: 2px $spacing-2;
   border-radius: 999px;
-  font-size: 12px;
-  line-height: 1.3;
+  font-size: 0.7rem;
+  font-weight: $font-weight-medium;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--background-card) 85%, transparent);
 }
 
-.badgeUnread {
-  background: var(--color-error);
+.badgePending {
+  background: color-mix(
+    in srgb,
+    var(--color-warning) 32%,
+    var(--background-card) 68%
+  );
+  color: color-mix(in srgb, var(--color-warning) 80%, var(--text-primary) 20%);
+  border-color: color-mix(in srgb, var(--color-warning) 55%, transparent);
 }
 
-.badgeBook {
-  background: var(--primary-dark);
+.badgeConfirmed {
+  background: color-mix(
+    in srgb,
+    var(--color-success) 32%,
+    var(--background-card) 68%
+  );
+  color: color-mix(in srgb, var(--color-success) 80%, var(--text-primary) 20%);
+  border-color: color-mix(in srgb, var(--color-success) 55%, transparent);
 }
 
-.badgeSwap {
-  background: var(--color-warning);
-  color: #000;
+.badgeReminder {
+  background: color-mix(
+    in srgb,
+    var(--color-info) 30%,
+    var(--background-card) 70%
+  );
+  color: color-mix(in srgb, var(--color-info) 80%, var(--text-primary) 20%);
+  border-color: color-mix(in srgb, var(--color-info) 55%, transparent);
+}
+
+.badgeAwaiting {
+  background: color-mix(
+    in srgb,
+    var(--primary-color) 25%,
+    var(--background-card) 75%
+  );
+  color: color-mix(in srgb, var(--primary-color) 82%, var(--text-primary) 18%);
+  border-color: color-mix(in srgb, var(--primary-color) 55%, transparent);
+}
+
+.badgeCancelled {
+  background: color-mix(
+    in srgb,
+    var(--text-secondary) 20%,
+    var(--background-card) 80%
+  );
+  color: color-mix(in srgb, var(--text-secondary) 90%, var(--text-primary) 10%);
+  border-color: color-mix(in srgb, var(--text-secondary) 55%, transparent);
 }
 
 .chat {
@@ -128,8 +183,8 @@
 .chatHeader {
   display: flex;
   align-items: center;
-  gap: $spacing-1;
-  padding: $spacing-1 $spacing-2;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
   border-bottom: 1px solid var(--border-color);
   background: var(--background-primary);
 }
@@ -141,13 +196,16 @@
 }
 
 .chatHeaderInfo .name {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: $font-weight-bold;
 }
 
 .status {
   font-size: $small-font-size;
   color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
 }
 
 .status::before {
@@ -156,8 +214,11 @@
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: #2ecc71;
-  margin-right: 6px;
+  background: color-mix(in srgb, var(--color-success) 80%, transparent);
+}
+
+.status[data-online='false']::before {
+  background: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 .actions {
@@ -175,20 +236,19 @@
   border: none;
   cursor: pointer;
   color: var(--text-secondary);
-  transition: background 0.15s;
+  transition: background $transition-duration-fast ease;
 
   &:hover {
-    background: color-mix(in srgb, var(--background-card) 86%, #000 14%);
+    background: color-mix(in srgb, var(--background-card) 86%, transparent);
   }
 }
 
 .messages {
   flex: 1;
-  padding: $spacing-1;
-  padding-bottom: $spacing-2;
+  padding: $spacing-3;
   display: flex;
   flex-direction: column;
-  gap: $spacing-1;
+  gap: $spacing-3;
   overflow-y: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -198,68 +258,79 @@
   }
 }
 
-.message {
-  max-width: 70%;
-  padding: $spacing-1 $spacing-2;
-  border-radius: 20px;
-  background: var(--background-card);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
-  align-self: flex-start;
-  font-size: 15px;
-  line-height: 1.45;
-}
-
-.me {
-  align-self: flex-end;
-  background: rgb(var(--primary-rgb));
-  color: #fff;
-}
-
-.bookCard {
-  display: flex;
-  gap: $spacing-2;
-  margin-top: $spacing-1;
-  padding: $spacing-1;
-  border-radius: 10px;
-  background: inherit;
-  box-shadow: inset 0 0 0 1px var(--color-primary-200);
-}
-
-.bookCard img {
-  width: 48px;
-  height: 68px;
-  object-fit: cover;
-  border-radius: 6px;
-}
-
-.bookTitle {
-  font-weight: 600;
-}
-
-.bookAuthor {
-  opacity: 0.8;
-  font-size: $small-font-size;
-}
-
-.time {
-  display: block;
-  font-size: 11px;
-  opacity: 0.65;
-  margin-top: $spacing-1;
-  text-align: right;
-}
-
-.message:not(.me) .time {
-  text-align: left;
-}
-
 .inputArea {
   display: flex;
-  align-items: center;
-  gap: $spacing-1;
-  padding: $spacing-1 $spacing-2;
+  align-items: flex-end;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
   background: var(--background-primary);
   border-top: 1px solid var(--border-color);
+  position: relative;
+}
+
+.templateToggle {
+  position: relative;
+}
+
+.templateToggle > button {
+  border-radius: rem(14px);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 45%, transparent);
+  background: color-mix(in srgb, var(--background-card) 92%, transparent);
+  color: color-mix(in srgb, var(--primary-color) 80%, var(--text-primary) 20%);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: $font-weight-medium;
+  padding: $spacing-2 $spacing-3;
+  transition: background $transition-duration-fast ease;
+
+  &:hover {
+    background: color-mix(in srgb, var(--background-card) 88%, transparent);
+  }
+}
+
+.templateMenu {
+  position: absolute;
+  top: calc(100% + $spacing-2);
+  left: 0;
+  width: rem(280px);
+  max-width: 80vw;
+  background: var(--background-primary);
+  border: 1px solid color-mix(in srgb, var(--border-color) 90%, transparent);
+  border-radius: rem(14px);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 12%);
+  padding: $spacing-2;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  z-index: $z-index-dropdown;
+}
+
+.templateMenu button {
+  border: none;
+  background: none;
+  padding: $spacing-2;
+  text-align: left;
+  border-radius: rem(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  color: var(--text-primary);
+
+  &:hover {
+    background: color-mix(in srgb, var(--background-card) 90%, transparent);
+  }
+}
+
+.templateMenuLabel {
+  font-weight: $font-weight-medium;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-primary) 25%);
+}
+
+.templateMenuText {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
 
 .inputWrapper {
@@ -268,9 +339,9 @@
 }
 
 .inputWrapper input {
-  width: calc(100% - $spacing-4 * 2);
-  height: 44px;
-  padding: 0 ($spacing-3 * 2) 0 $spacing-2;
+  width: 100%;
+  height: 46px;
+  padding: 0 ($spacing-4 + $spacing-2) 0 $spacing-3;
   border: 1px solid var(--border-color);
   border-radius: 24px;
   background: var(--background-primary);
@@ -278,15 +349,17 @@
 
   &:focus {
     outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+    outline-offset: 1px;
   }
 }
 
 .inputIcons {
   position: absolute;
   top: 50%;
-  right: $spacing-1;
+  right: $spacing-2;
   transform: translateY(-50%);
   display: flex;
+  gap: $spacing-1;
 }
 
 .inputIcons button {
@@ -294,16 +367,16 @@
   border: none;
   cursor: pointer;
   color: var(--text-secondary);
-  font-size: 1.2rem;
+  font-size: 1.1rem;
 }
 
 .sendButton {
   background: rgb(var(--primary-rgb));
   color: #fff;
   border: none;
-  border-radius: 10px;
-  padding: 10px 16px;
-  font-weight: 600;
+  border-radius: 12px;
+  padding: $spacing-2 $spacing-3;
+  font-weight: $font-weight-bold;
   transition:
     transform 0.04s ease,
     background 0.15s;
@@ -315,6 +388,11 @@
 
   &:hover {
     background: var(--primary-dark);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 }
 
@@ -330,5 +408,26 @@
   background: var(--color-error);
   color: #fff;
   text-align: center;
-  padding: $spacing-1;
+  padding: $spacing-2;
+}
+
+@media (max-width: $breakpoint-desktop) {
+  .sidebar {
+    width: rem(300px);
+  }
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .wrapper {
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .chatHeader {
+    align-items: flex-start;
+  }
 }

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -7,47 +7,233 @@ import { ReactComponent as AttachIcon } from '@src/assets/icons/attachments.svg'
 import { ReactComponent as EmojiIcon } from '@src/assets/icons/emoji.svg'
 import { ReactComponent as InfoIcon } from '@src/assets/icons/info.svg'
 
+import { BubbleCancellation } from './bubbles/BubbleCancellation'
+import { BubbleConfirmation } from './bubbles/BubbleConfirmation'
+import { BubblePostCheck } from './bubbles/BubblePostCheck'
+import { BubbleProposal } from './bubbles/BubbleProposal'
+import { BubbleReminder } from './bubbles/BubbleReminder'
+import { BubbleReschedule } from './bubbles/BubbleReschedule'
+import { BubbleText } from './bubbles/BubbleText'
+import { BubbleTip } from './bubbles/BubbleTip'
 import styles from './Messages.module.scss'
-import { Conversation, Message } from './Messages.types'
+import { Conversation, ConversationBadge, Message } from './Messages.types'
+
+type TemplateShortcut = {
+  id: string
+  label: string
+  text: string
+}
+
+const badgeClassMap: Record<ConversationBadge, string> = {
+  proposalPending: styles.badgePending,
+  agreementConfirmed: styles.badgeConfirmed,
+  reminderScheduled: styles.badgeReminder,
+  awaitingFeedback: styles.badgeAwaiting,
+  cancelled: styles.badgeCancelled,
+}
 
 export const Messages = () => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [conversations] = useState<Conversation[]>(mockConversations)
   const [selectedId, setSelectedId] = useState<number | null>(
     mockConversations[0]?.id ?? null
   )
   const [text, setText] = useState('')
+  const [showTemplates, setShowTemplates] = useState(false)
   const { messages, sendMessage, currentUser, isConnected, error } =
     useChatSocket()
 
-  const selected = conversations.find((c) => c.id === selectedId)
+  const selected = conversations.find((c) => c.id === selectedId) ?? null
 
-  const mappedMessages: Message[] = useMemo(() => {
+  const templateShortcuts: TemplateShortcut[] = useMemo(
+    () => [
+      {
+        id: 'interest',
+        label: t('community.messages.chat.templates.interest.label'),
+        text: t('community.messages.chat.templates.interest.text'),
+      },
+      {
+        id: 'availability',
+        label: t('community.messages.chat.templates.availability.label'),
+        text: t('community.messages.chat.templates.availability.text'),
+      },
+      {
+        id: 'place',
+        label: t('community.messages.chat.templates.place.label'),
+        text: t('community.messages.chat.templates.place.text'),
+      },
+    ],
+    [t]
+  )
+
+  const realtimeMessages: Message[] = useMemo(() => {
     if (!selected) return []
     return messages
-      .filter((m) => m.channel === selected.user.name)
+      .filter((m) => m.channel === selected.channel)
       .map((m, idx) => ({
-        id: idx,
-        sender: m.user.id === currentUser?.id ? 'me' : 'them',
+        id: `socket-${idx}-${m.timestamp}`,
+        role: m.user.id === currentUser?.id ? 'me' : 'them',
+        type: 'text',
         text: m.text,
-        time: new Date(m.timestamp).toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-        }),
+        createdAt: m.timestamp,
       }))
   }, [messages, currentUser, selected])
 
+  const timeline: Message[] = useMemo(() => {
+    if (!selected) return []
+    return [...selected.messages, ...realtimeMessages].sort((a, b) => {
+      const aTime = new Date(a.createdAt).getTime()
+      const bTime = new Date(b.createdAt).getTime()
+      return aTime - bTime
+    })
+  }, [selected, realtimeMessages])
+
+  const formatTime = (message: Message) => {
+    if (message.displayTime) return message.displayTime
+    const locale = i18n?.language ?? 'es'
+    return new Date(message.createdAt).toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  const getSnippet = (message: Message) => {
+    switch (message.type) {
+      case 'text':
+      case 'template':
+        return message.text
+      case 'proposal':
+        return t('community.messages.chat.snippets.proposal', {
+          book: message.proposal.book.title,
+        })
+      case 'confirmation':
+        return t('community.messages.chat.snippets.confirmation', {
+          book: message.confirmation.book.title,
+        })
+      case 'reminder':
+        return t('community.messages.chat.snippets.reminder', {
+          time: message.reminder.details.schedule.time,
+        })
+      case 'reschedule':
+        return t('community.messages.chat.snippets.reschedule')
+      case 'cancellation':
+        return t('community.messages.chat.snippets.cancellation')
+      case 'post-check':
+        return t('community.messages.chat.snippets.postMeeting')
+      case 'safety-tip':
+        return t('community.messages.chat.snippets.tip')
+      default:
+        return ''
+    }
+  }
+
+  const badgeLabels = useMemo(
+    () => ({
+      proposalPending: t('community.messages.chat.badges.proposalPending'),
+      agreementConfirmed: t(
+        'community.messages.chat.badges.agreementConfirmed'
+      ),
+      reminderScheduled: t('community.messages.chat.badges.reminderScheduled'),
+      awaitingFeedback: t('community.messages.chat.badges.awaitingFeedback'),
+      cancelled: t('community.messages.chat.badges.cancelled'),
+    }),
+    [t]
+  )
+
   const handleSend = () => {
     if (!text.trim() || selectedId === null || !selected) return
-    sendMessage(text.trim(), selected.user.name)
+    sendMessage(text.trim(), selected.channel)
     setText('')
+  }
+
+  const handleTemplateInsert = (value: string) => {
+    setText(value)
+    setShowTemplates(false)
+  }
+
+  const renderMessage = (message: Message) => {
+    const timeLabel = formatTime(message)
+    switch (message.type) {
+      case 'text':
+        return (
+          <BubbleText
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'template':
+        return (
+          <BubbleText
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'proposal':
+        return (
+          <BubbleProposal
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'confirmation':
+        return (
+          <BubbleConfirmation
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'reminder':
+        return (
+          <BubbleReminder
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'reschedule':
+        return (
+          <BubbleReschedule
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'cancellation':
+        return (
+          <BubbleCancellation
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'post-check':
+        return (
+          <BubblePostCheck
+            key={message.id}
+            message={message}
+            timeLabel={timeLabel}
+          />
+        )
+      case 'safety-tip':
+        return (
+          <BubbleTip key={message.id} message={message} timeLabel={timeLabel} />
+        )
+      default:
+        return null
+    }
   }
 
   return (
     <div className={styles.wrapper}>
       {!isConnected && (
         <div className={styles.offlineBanner} role="alert">
-          {error ? `Disconnected: ${error}` : 'Disconnected'}
+          {error
+            ? t('community.messages.chat.offlineWithError', { error })
+            : t('community.messages.chat.offline')}
         </div>
       )}
       <div className={styles.content}>
@@ -56,52 +242,54 @@ export const Messages = () => {
             <h2>{t('community.messages.title')}</h2>
             <input
               className={styles.search}
-              placeholder="Search"
-              aria-label="Search conversations"
+              placeholder={t('community.messages.chat.searchPlaceholder')}
+              aria-label={t('community.messages.chat.searchAria')}
             />
           </div>
           <ul className={styles.conversationList}>
-            {conversations.map((conv) => (
-              <li
-                key={conv.id}
-                className={`${styles.conversationItem} ${selectedId === conv.id ? styles.conversationItemActive : ''}`}
-                onClick={() => setSelectedId(conv.id)}
-              >
-                <img
-                  src={conv.user.avatar}
-                  alt={conv.user.name}
-                  className={styles.avatar}
-                />
-                <div className={styles.conversationInfo}>
-                  <span className={styles.name}>{conv.user.name}</span>
-                  <span className={styles.snippet}>
-                    {(() => {
-                      const lastMsg = conv.messages[conv.messages.length - 1]
-                      if (lastMsg?.text) return lastMsg.text
-                      if (lastMsg?.book) return 'Shared a book'
-                      return ''
-                    })()}
-                  </span>
-                </div>
-                <div className={styles.badges}>
-                  {conv.badges.includes('unread') && (
-                    <span className={`${styles.badge} ${styles.badgeUnread}`}>
-                      Unread
-                    </span>
-                  )}
-                  {conv.badges.includes('book') && (
-                    <span className={`${styles.badge} ${styles.badgeBook}`}>
-                      Book
-                    </span>
-                  )}
-                  {conv.badges.includes('swap') && (
-                    <span className={`${styles.badge} ${styles.badgeSwap}`}>
-                      Swap Offer
-                    </span>
-                  )}
-                </div>
-              </li>
-            ))}
+            {conversations.map((conv) => {
+              const lastMessage = conv.messages[conv.messages.length - 1]
+              const snippet = lastMessage ? getSnippet(lastMessage) : ''
+              return (
+                <li
+                  key={conv.id}
+                  className={`${styles.conversationItem} ${selectedId === conv.id ? styles.conversationItemActive : ''}`}
+                  onClick={() => {
+                    setSelectedId(conv.id)
+                    setShowTemplates(false)
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      setSelectedId(conv.id)
+                      setShowTemplates(false)
+                    }
+                  }}
+                >
+                  <img
+                    src={conv.user.avatar}
+                    alt={conv.user.name}
+                    className={styles.avatar}
+                  />
+                  <div className={styles.conversationInfo}>
+                    <span className={styles.name}>{conv.user.name}</span>
+                    <span className={styles.snippet}>{snippet}</span>
+                  </div>
+                  <div className={styles.badges}>
+                    {conv.badges.map((badge) => (
+                      <span
+                        key={badge}
+                        className={`${styles.badge} ${badgeClassMap[badge]}`}
+                      >
+                        {badgeLabels[badge]}
+                      </span>
+                    ))}
+                  </div>
+                </li>
+              )
+            })}
           </ul>
         </aside>
         {selected ? (
@@ -114,62 +302,84 @@ export const Messages = () => {
               />
               <div className={styles.chatHeaderInfo}>
                 <span className={styles.name}>{selected.user.name}</span>
-                <span className={styles.status}>
+                <span
+                  className={styles.status}
+                  data-online={selected.user.online}
+                >
                   {selected.user.online
-                    ? 'Online'
-                    : `Last seen ${selected.user.lastSeen}`}
+                    ? t('community.messages.chat.status.online')
+                    : t('community.messages.chat.status.lastSeen', {
+                        value: selected.user.lastSeen ?? '—',
+                      })}
                 </span>
               </div>
               <div className={styles.actions}>
-                <button aria-label="Profile info">
+                <button
+                  aria-label={t('community.messages.chat.actions.profile')}
+                >
                   <InfoIcon />
                 </button>
               </div>
             </header>
             <div className={styles.messages}>
-              {mappedMessages.map((msg) => (
-                <div
-                  key={msg.id}
-                  className={`${styles.message} ${msg.sender === 'me' ? styles.me : ''}`}
-                >
-                  {msg.text && <p>{msg.text}</p>}
-                  {msg.book && (
-                    <div className={styles.bookCard}>
-                      <img
-                        src={msg.book.cover}
-                        alt={`Cover of ${msg.book.title}`}
-                      />
-                      <div>
-                        <div className={styles.bookTitle}>{msg.book.title}</div>
-                        <div className={styles.bookAuthor}>
-                          {msg.book.author}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <span className={styles.time}>{msg.time}</span>
-                </div>
-              ))}
+              {timeline.map((message) => renderMessage(message))}
             </div>
             <div className={styles.inputArea}>
+              <div className={styles.templateToggle}>
+                <button
+                  type="button"
+                  onClick={() => setShowTemplates((prev) => !prev)}
+                  aria-expanded={showTemplates}
+                  aria-controls="template-menu"
+                >
+                  {t('community.messages.chat.templateButton')}
+                </button>
+                {showTemplates ? (
+                  <div
+                    id="template-menu"
+                    role="menu"
+                    className={styles.templateMenu}
+                  >
+                    {templateShortcuts.map((template) => (
+                      <button
+                        key={template.id}
+                        type="button"
+                        role="menuitem"
+                        onClick={() => handleTemplateInsert(template.text)}
+                      >
+                        <span className={styles.templateMenuLabel}>
+                          {template.label}
+                        </span>
+                        <span className={styles.templateMenuText}>
+                          {template.text}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
               <div className={styles.inputWrapper}>
                 <input
                   value={text}
                   onChange={(e) => setText(e.target.value)}
-                  placeholder="Message..."
+                  placeholder={t('community.messages.chat.inputPlaceholder')}
                   disabled={!isConnected}
                 />
                 <div className={styles.inputIcons}>
-                  <button aria-label="Attachments">
+                  <button
+                    aria-label={t('community.messages.chat.actions.attach')}
+                  >
                     <AttachIcon />
                   </button>
-                  <button aria-label="Emoji">
+                  <button
+                    aria-label={t('community.messages.chat.actions.emoji')}
+                  >
                     <EmojiIcon />
                   </button>
                 </div>
               </div>
               <button
-                aria-label="Send"
+                aria-label={t('community.messages.chat.actions.send')}
                 onClick={handleSend}
                 className={styles.sendButton}
                 disabled={!isConnected}
@@ -180,7 +390,7 @@ export const Messages = () => {
           </div>
         ) : (
           <div className={styles.placeholder}>
-            Select a conversation to start
+            {t('community.messages.chat.emptyState')}
           </div>
         )}
       </div>

--- a/frontend/src/components/messages/Messages.types.ts
+++ b/frontend/src/components/messages/Messages.types.ts
@@ -1,25 +1,127 @@
-export type Book = {
-  title: string
-  author: string
-  cover: string
+export type MessageRole = 'me' | 'them' | 'system'
+
+export type AgreementLocationType = 'bookCorner' | 'public'
+
+export type AgreementLocation = {
+  name: string
+  area: string
+  type: AgreementLocationType
 }
 
-export type Message = {
-  id: number
-  sender: 'me' | 'them'
-  text?: string
-  book?: Book
+export type AgreementSchedule = {
+  day: string
   time: string
 }
 
+export type AgreementBook = {
+  title: string
+}
+
+export type AgreementDetails = {
+  location: AgreementLocation
+  schedule: AgreementSchedule
+  book: AgreementBook
+}
+
+export type MessageBase = {
+  id: string
+  role: MessageRole
+  createdAt: string
+  /**
+   * Optional pre-formatted time label. When provided it takes precedence over
+   * the auto-generated value to keep the mock conversation predictable during
+   * visual QA.
+   */
+  displayTime?: string
+}
+
+export type TextMessage = MessageBase & {
+  type: 'text'
+  text: string
+}
+
+export type TemplateMessage = MessageBase & {
+  type: 'template'
+  text: string
+  templateLabel: string
+}
+
+export type ProposalMessage = MessageBase & {
+  type: 'proposal'
+  proposal: AgreementDetails
+}
+
+export type ConfirmationMessage = MessageBase & {
+  type: 'confirmation'
+  confirmation: AgreementDetails & { confirmedBy: string }
+}
+
+export type ReminderMessage = MessageBase & {
+  type: 'reminder'
+  reminder: {
+    message: string
+    details: AgreementDetails
+  }
+}
+
+export type RescheduleMessage = MessageBase & {
+  type: 'reschedule'
+  reschedule: {
+    note: string
+    previous: AgreementDetails
+    proposed: {
+      schedule: AgreementSchedule
+      location?: AgreementLocation
+    }
+  }
+}
+
+export type CancellationMessage = MessageBase & {
+  type: 'cancellation'
+  cancellation: {
+    reason: string
+    details?: AgreementDetails
+  }
+}
+
+export type PostCheckMessage = MessageBase & {
+  type: 'post-check'
+  question: string
+  details: AgreementDetails
+}
+
+export type SafetyTipMessage = MessageBase & {
+  type: 'safety-tip'
+  tip: string
+}
+
+export type Message =
+  | TextMessage
+  | TemplateMessage
+  | ProposalMessage
+  | ConfirmationMessage
+  | ReminderMessage
+  | RescheduleMessage
+  | CancellationMessage
+  | PostCheckMessage
+  | SafetyTipMessage
+
+export type ConversationBadge =
+  | 'proposalPending'
+  | 'agreementConfirmed'
+  | 'reminderScheduled'
+  | 'awaitingFeedback'
+  | 'cancelled'
+
 export type Conversation = {
   id: number
+  channel: string
   user: {
     name: string
     avatar: string
     online: boolean
     lastSeen?: string
   }
-  badges: ('unread' | 'book' | 'swap')[]
+  badges: ConversationBadge[]
   messages: Message[]
 }

--- a/frontend/src/components/messages/bubbles/AgreementDetails.tsx
+++ b/frontend/src/components/messages/bubbles/AgreementDetails.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+
+import { AgreementDetails } from '../Messages.types'
+
+import styles from './BubbleContent.module.scss'
+
+type AgreementDetailsProps = {
+  details: AgreementDetails
+}
+
+export const AgreementDetailsSummary = ({ details }: AgreementDetailsProps) => {
+  const { t } = useTranslation()
+
+  const placeLabel =
+    details.location.type === 'bookCorner'
+      ? t('community.messages.chat.location.bookCorner')
+      : t('community.messages.chat.location.publicSpace')
+
+  return (
+    <div className={styles.agreementDetails}>
+      <ul className={styles.list}>
+        <li className={styles.item}>
+          <span className={styles.label}>
+            {t('community.messages.chat.fields.place')}
+          </span>
+          <span className={styles.value}>
+            {details.location.name}
+            <span
+              className={styles.muted}
+            >{` — ${details.location.area}`}</span>
+            <span className={styles.badge}>{placeLabel}</span>
+          </span>
+        </li>
+        <li className={styles.item}>
+          <span className={styles.label}>
+            {t('community.messages.chat.fields.schedule')}
+          </span>
+          <span className={styles.value}>
+            {details.schedule.day}
+            <span
+              className={styles.muted}
+            >{` · ${details.schedule.time}`}</span>
+          </span>
+        </li>
+        <li className={styles.item}>
+          <span className={styles.label}>
+            {t('community.messages.chat.fields.book')}
+          </span>
+          <span className={styles.value}>{details.book.title}</span>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleBase.module.scss
+++ b/frontend/src/components/messages/bubbles/BubbleBase.module.scss
@@ -1,0 +1,176 @@
+@import '@styles/variables';
+
+.wrapper {
+  --bubble-bg: color-mix(in srgb, var(--background-card) 92%, transparent);
+  --bubble-border: color-mix(in srgb, var(--border-color) 86%, transparent);
+  --bubble-text: var(--text-primary);
+
+  display: flex;
+  width: 100%;
+  gap: $spacing-1;
+}
+
+.me {
+  justify-content: flex-end;
+}
+
+.them {
+  justify-content: flex-start;
+}
+
+.system {
+  justify-content: center;
+}
+
+.surface {
+  width: min(100%, rem(420px));
+  background: var(--bubble-bg);
+  border: 1px solid var(--bubble-border);
+  border-radius: rem(18px);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 6%);
+  color: var(--bubble-text);
+  padding: $spacing-3;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.header {
+  font-size: $small-font-size;
+  font-weight: $font-weight-bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--bubble-text) 82%, var(--text-secondary) 18%);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  color: var(--bubble-text);
+}
+
+.actions {
+  margin-top: $spacing-1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.meta {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--bubble-text) 72%, var(--text-secondary) 28%);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.meta time {
+  font-variant-numeric: tabular-nums;
+}
+
+.tone-primary {
+  --bubble-bg: color-mix(
+    in srgb,
+    rgb(var(--primary-rgb)) 20%,
+    var(--background-card) 80%
+  );
+  --bubble-border: color-mix(in srgb, var(--primary-color) 60%, transparent);
+}
+
+.tone-success {
+  --bubble-bg: color-mix(
+    in srgb,
+    var(--color-success) 16%,
+    var(--background-card) 84%
+  );
+  --bubble-border: color-mix(in srgb, var(--color-success) 55%, transparent);
+}
+
+.tone-warning {
+  --bubble-bg: color-mix(
+    in srgb,
+    var(--color-warning) 22%,
+    var(--background-card) 78%
+  );
+  --bubble-border: color-mix(in srgb, var(--color-warning) 55%, transparent);
+}
+
+.tone-info {
+  --bubble-bg: color-mix(
+    in srgb,
+    var(--color-info) 18%,
+    var(--background-card) 82%
+  );
+  --bubble-border: color-mix(in srgb, var(--color-info) 55%, transparent);
+}
+
+.tone-secondary {
+  --bubble-bg: color-mix(
+    in srgb,
+    var(--background-card) 86%,
+    var(--text-secondary) 14%
+  );
+  --bubble-border: color-mix(in srgb, var(--border-color) 75%, transparent);
+}
+
+.actionButton {
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--bubble-border);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.9rem;
+  font-weight: $font-weight-medium;
+  gap: $spacing-1;
+  padding: $spacing-1 $spacing-3;
+  transition:
+    background $transition-duration-fast ease,
+    border-color $transition-duration-fast ease,
+    color $transition-duration-fast ease;
+  background: color-mix(in srgb, var(--background-primary) 92%, transparent);
+  color: var(--text-primary);
+}
+
+.actionButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.actionButtonPrimary {
+  background: rgb(var(--primary-rgb));
+  border-color: rgb(var(--primary-rgb));
+  color: #fff;
+}
+
+[data-theme='dark'] .actionButtonPrimary {
+  color: #fff;
+}
+
+.actionButtonSecondary {
+  background: transparent;
+  border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
+}
+
+.actionButtonGhost {
+  background: transparent;
+  border-color: transparent;
+  color: color-mix(in srgb, var(--text-secondary) 92%, var(--bubble-text) 8%);
+}
+
+.templateLabel {
+  align-self: flex-start;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 45%, transparent);
+  color: color-mix(in srgb, var(--primary-color) 85%, var(--bubble-text) 15%);
+  font-size: 0.75rem;
+  font-weight: $font-weight-medium;
+  letter-spacing: 0.03em;
+  padding: 2px $spacing-2;
+  text-transform: uppercase;
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .surface {
+    width: min(100%, rem(360px));
+  }
+}

--- a/frontend/src/components/messages/bubbles/BubbleBase.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleBase.tsx
@@ -1,0 +1,89 @@
+import { ReactNode } from 'react'
+
+import { MessageRole } from '../Messages.types'
+
+import styles from './BubbleBase.module.scss'
+
+export type BubbleTone =
+  | 'neutral'
+  | 'primary'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'secondary'
+
+export type BubbleBaseProps = {
+  role: MessageRole
+  tone?: BubbleTone
+  header?: ReactNode
+  children: ReactNode
+  actions?: ReactNode
+  meta?: ReactNode
+  className?: string
+  ariaLabel?: string
+}
+
+export const BubbleBase = ({
+  role,
+  tone = 'neutral',
+  header,
+  children,
+  actions,
+  meta,
+  className,
+  ariaLabel,
+}: BubbleBaseProps) => {
+  const toneClass = tone !== 'neutral' ? styles[`tone-${tone}`] : undefined
+  const classes = [styles.wrapper, styles[role], toneClass, className]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={classes} role="group" aria-label={ariaLabel}>
+      <div className={styles.surface}>
+        {header && <div className={styles.header}>{header}</div>}
+        <div className={styles.body}>{children}</div>
+        {actions ? <div className={styles.actions}>{actions}</div> : null}
+        {meta ? <div className={styles.meta}>{meta}</div> : null}
+      </div>
+    </div>
+  )
+}
+
+export const BubbleTemplateLabel = ({ children }: { children: ReactNode }) => (
+  <span className={styles.templateLabel}>{children}</span>
+)
+
+export type BubbleActionVariant = 'primary' | 'secondary' | 'ghost'
+
+export type BubbleActionButtonProps = {
+  children: ReactNode
+  onClick?: () => void
+  variant?: BubbleActionVariant
+  ariaLabel?: string
+}
+
+export const BubbleActionButton = ({
+  children,
+  onClick,
+  variant = 'secondary',
+  ariaLabel,
+}: BubbleActionButtonProps) => {
+  const variantClass =
+    variant === 'primary'
+      ? styles.actionButtonPrimary
+      : variant === 'ghost'
+        ? styles.actionButtonGhost
+        : styles.actionButtonSecondary
+
+  return (
+    <button
+      type="button"
+      className={`${styles.actionButton} ${variantClass}`}
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleCancellation.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleCancellation.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next'
+
+import { CancellationMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleBase } from './BubbleBase'
+import styles from './BubbleContent.module.scss'
+
+export type BubbleCancellationProps = {
+  message: CancellationMessage
+  timeLabel: string
+}
+
+export const BubbleCancellation = ({
+  message,
+  timeLabel,
+}: BubbleCancellationProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="secondary"
+      header={t('community.messages.chat.labels.cancellation')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.cancellation')}
+    >
+      <p className={styles.note}>
+        {t('community.messages.chat.cancellation.reason', {
+          reason: message.cancellation.reason,
+        })}
+      </p>
+      {message.cancellation.details ? (
+        <AgreementDetailsSummary details={message.cancellation.details} />
+      ) : null}
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleConfirmation.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleConfirmation.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next'
+
+import { ConfirmationMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleBase } from './BubbleBase'
+
+export type BubbleConfirmationProps = {
+  message: ConfirmationMessage
+  timeLabel: string
+}
+
+export const BubbleConfirmation = ({
+  message,
+  timeLabel,
+}: BubbleConfirmationProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="success"
+      header={t('community.messages.chat.labels.confirmation')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.confirmation')}
+    >
+      <p>
+        {t('community.messages.chat.confirmedBy', {
+          name: message.confirmation.confirmedBy,
+        })}
+      </p>
+      <AgreementDetailsSummary details={message.confirmation} />
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleContent.module.scss
+++ b/frontend/src/components/messages/bubbles/BubbleContent.module.scss
@@ -1,0 +1,80 @@
+@import '@styles/variables';
+
+.agreementDetails {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.sectionTitle {
+  font-size: 0.85rem;
+  font-weight: $font-weight-medium;
+  color: color-mix(in srgb, var(--text-primary) 84%, var(--text-secondary) 16%);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.label {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-secondary) 82%, var(--text-primary) 18%);
+}
+
+.value {
+  font-size: 0.95rem;
+  font-weight: $font-weight-medium;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  align-items: center;
+  color: inherit;
+}
+
+.badge {
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 45%, transparent);
+  color: color-mix(in srgb, var(--primary-color) 82%, var(--text-primary) 18%);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  padding: 2px $spacing-2;
+  text-transform: uppercase;
+}
+
+.muted {
+  color: color-mix(in srgb, var(--text-secondary) 88%, var(--text-primary) 12%);
+}
+
+.note {
+  color: color-mix(in srgb, var(--text-secondary) 90%, var(--text-primary) 10%);
+  font-size: 0.9rem;
+}
+
+.divider {
+  border: 0;
+  border-top: 1px solid
+    color-mix(
+      in srgb,
+      var(--bubble-border, var(--border-color)) 90%,
+      transparent
+    );
+  margin: $spacing-2 0;
+}
+
+.actionsNote {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--text-secondary) 85%, var(--text-primary) 15%);
+}

--- a/frontend/src/components/messages/bubbles/BubblePostCheck.tsx
+++ b/frontend/src/components/messages/bubbles/BubblePostCheck.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next'
+
+import { PostCheckMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleActionButton, BubbleBase } from './BubbleBase'
+import styles from './BubbleContent.module.scss'
+
+export type BubblePostCheckProps = {
+  message: PostCheckMessage
+  timeLabel: string
+}
+
+export const BubblePostCheck = ({
+  message,
+  timeLabel,
+}: BubblePostCheckProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="secondary"
+      header={t('community.messages.chat.labels.postMeeting')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.postMeeting')}
+    >
+      <p>{message.question}</p>
+      <AgreementDetailsSummary details={message.details} />
+      <BubbleActionButton variant="primary">
+        {t('community.messages.chat.actions.yes')}
+      </BubbleActionButton>
+      <BubbleActionButton>
+        {t('community.messages.chat.actions.no')}
+      </BubbleActionButton>
+      <p className={styles.actionsNote}>
+        {t('community.messages.chat.postCheck.note')}
+      </p>
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleProposal.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleProposal.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+
+import { ProposalMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleActionButton, BubbleBase } from './BubbleBase'
+
+export type BubbleProposalProps = {
+  message: ProposalMessage
+  timeLabel: string
+}
+
+export const BubbleProposal = ({ message, timeLabel }: BubbleProposalProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="warning"
+      header={t('community.messages.chat.labels.proposal')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.proposal')}
+    >
+      <AgreementDetailsSummary details={message.proposal} />
+      <BubbleActionButton variant="primary">
+        {t('community.messages.chat.actions.confirm')}
+      </BubbleActionButton>
+      <BubbleActionButton>
+        {t('community.messages.chat.actions.proposeChange')}
+      </BubbleActionButton>
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleReminder.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleReminder.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next'
+
+import { ReminderMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleBase } from './BubbleBase'
+
+export type BubbleReminderProps = {
+  message: ReminderMessage
+  timeLabel: string
+}
+
+export const BubbleReminder = ({ message, timeLabel }: BubbleReminderProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="info"
+      header={t('community.messages.chat.labels.reminder')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.reminder')}
+    >
+      <p>{message.reminder.message}</p>
+      <AgreementDetailsSummary details={message.reminder.details} />
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleReschedule.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleReschedule.tsx
@@ -1,0 +1,71 @@
+import { useTranslation } from 'react-i18next'
+
+import { RescheduleMessage } from '../Messages.types'
+
+import { AgreementDetailsSummary } from './AgreementDetails'
+import { BubbleActionButton, BubbleBase } from './BubbleBase'
+import styles from './BubbleContent.module.scss'
+
+export type BubbleRescheduleProps = {
+  message: RescheduleMessage
+  timeLabel: string
+}
+
+export const BubbleReschedule = ({
+  message,
+  timeLabel,
+}: BubbleRescheduleProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="warning"
+      header={t('community.messages.chat.labels.reschedule')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.reschedule')}
+    >
+      <p className={styles.note}>{message.reschedule.note}</p>
+      <span className={styles.sectionTitle}>
+        {t('community.messages.chat.reschedule.previous')}
+      </span>
+      <AgreementDetailsSummary details={message.reschedule.previous} />
+      <hr className={styles.divider} />
+      <span className={styles.sectionTitle}>
+        {t('community.messages.chat.reschedule.proposed')}
+      </span>
+      <ul className={styles.list}>
+        <li className={styles.item}>
+          <span className={styles.label}>
+            {t('community.messages.chat.fields.schedule')}
+          </span>
+          <span className={styles.value}>
+            {message.reschedule.proposed.schedule.day}
+            <span
+              className={styles.muted}
+            >{` · ${message.reschedule.proposed.schedule.time}`}</span>
+          </span>
+        </li>
+        {message.reschedule.proposed.location ? (
+          <li className={styles.item}>
+            <span className={styles.label}>
+              {t('community.messages.chat.fields.place')}
+            </span>
+            <span className={styles.value}>
+              {message.reschedule.proposed.location.name}
+              <span
+                className={styles.muted}
+              >{` — ${message.reschedule.proposed.location.area}`}</span>
+            </span>
+          </li>
+        ) : null}
+      </ul>
+      <BubbleActionButton variant="primary">
+        {t('community.messages.chat.actions.accept')}
+      </BubbleActionButton>
+      <BubbleActionButton>
+        {t('community.messages.chat.actions.suggestAnother')}
+      </BubbleActionButton>
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleText.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleText.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+
+import { TemplateMessage, TextMessage } from '../Messages.types'
+
+import { BubbleBase, BubbleTemplateLabel, BubbleTone } from './BubbleBase'
+
+export type BubbleTextProps = {
+  message: TextMessage | TemplateMessage
+  timeLabel: string
+}
+
+export const BubbleText = ({ message, timeLabel }: BubbleTextProps) => {
+  const { t } = useTranslation()
+  const tone: BubbleTone = message.role === 'me' ? 'primary' : 'secondary'
+
+  const header =
+    message.type === 'template' ? (
+      <BubbleTemplateLabel>
+        {message.templateLabel || t('community.messages.chat.labels.template')}
+      </BubbleTemplateLabel>
+    ) : null
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone={tone}
+      header={header}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+    >
+      <p>{message.text}</p>
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/bubbles/BubbleTip.tsx
+++ b/frontend/src/components/messages/bubbles/BubbleTip.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next'
+
+import { SafetyTipMessage } from '../Messages.types'
+
+import { BubbleBase } from './BubbleBase'
+
+export type BubbleTipProps = {
+  message: SafetyTipMessage
+  timeLabel: string
+}
+
+export const BubbleTip = ({ message, timeLabel }: BubbleTipProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BubbleBase
+      role={message.role}
+      tone="secondary"
+      header={t('community.messages.chat.labels.tip')}
+      meta={<time dateTime={message.createdAt}>{timeLabel}</time>}
+      ariaLabel={t('community.messages.chat.a11y.tip')}
+    >
+      <p>{message.tip}</p>
+    </BubbleBase>
+  )
+}

--- a/frontend/tests/components/messages/Messages.test.tsx
+++ b/frontend/tests/components/messages/Messages.test.tsx
@@ -1,4 +1,5 @@
 import { Messages } from '@components/messages/Messages'
+import { fireEvent } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 import { renderWithProviders } from '../../test-utils'
@@ -18,7 +19,39 @@ describe('Messages component', () => {
     const { getByText, getByPlaceholderText } = renderWithProviders(
       <Messages />
     )
-    expect(getByText(/disconnected/i)).toBeInTheDocument()
-    expect(getByPlaceholderText('Message...')).toBeDisabled()
+    expect(
+      getByText('community.messages.chat.offlineWithError')
+    ).toBeInTheDocument()
+    expect(
+      getByPlaceholderText('community.messages.chat.inputPlaceholder')
+    ).toBeDisabled()
+  })
+
+  test('renders agreement flow with proposal, reminders and post-check', () => {
+    const { getByText, getAllByText } = renderWithProviders(<Messages />)
+
+    expect(
+      getByText('community.messages.chat.labels.proposal')
+    ).toBeInTheDocument()
+    expect(getAllByText('Rincón Parque Central')[0]).toBeInTheDocument()
+    expect(getByText('¿Se concretó el intercambio?')).toBeInTheDocument()
+    expect(
+      getAllByText('community.messages.chat.actions.confirm')[0]
+    ).toBeInTheDocument()
+  })
+
+  test('opens template menu from shortcut button', () => {
+    const { getByRole, getByText } = renderWithProviders(<Messages />)
+    const button = getByRole('button', {
+      name: 'community.messages.chat.templateButton',
+    })
+    fireEvent.click(button)
+
+    expect(
+      getByText('community.messages.chat.templates.interest.label')
+    ).toBeInTheDocument()
+    expect(
+      getByText('community.messages.chat.templates.interest.text')
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/tests/pages/messages/MessagesPage.test.tsx
+++ b/frontend/tests/pages/messages/MessagesPage.test.tsx
@@ -7,6 +7,8 @@ import { renderWithProviders } from '../../test-utils'
 describe('MessagesPage', () => {
   test('renders message input', () => {
     const { getByPlaceholderText } = renderWithProviders(<MessagesPage />)
-    expect(getByPlaceholderText('Message...')).toBeInTheDocument()
+    expect(
+      getByPlaceholderText('community.messages.chat.inputPlaceholder')
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add BubbleBase wrapper and agreement-specific bubble components to support proposals, confirmations, reminders, reschedules, cancellations, safety tips, and follow-up states in the messaging UI
- refresh the mocked conversations, translations, and chat layout to surface badges, template shortcuts, and agreement details with light/dark tone support
- document the agreement-focused messaging flow and update the backlog to reflect the frontend mock status

## Testing
- npm run format:backend
- npm run format:frontend
- npm run test:backend *(fails: Postgres not running in CI container)*
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d92d819860832eaa384125e88f1861