### PR TITLE
Add community and feed tests to raise coverage

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -117,6 +117,7 @@ Feature 4.1 Mapa y listados
   - Éxito: resultados consistentes entre lista y mapa.
   - Actualización 2025-10-09: se integró en Community la tira de Rincones cercanos, un mini-mapa en la barra lateral y la vinculación de publicaciones/flujo de publicación con Rincones (chips y selector), quedando pendiente la conexión con datos en tiempo real y filtros avanzados.
   - Actualización 2025-10-12: se desplegó la vista `/map` como hub territorial con rail de filtros y heatmap sobre mocks MSW; el panel de detalle queda como bloque placeholder hasta la próxima iteración mientras se termina de definir contenido y acciones. Resta conectar servicios reales y geocercas dinámicas.
+  - Actualización 2025-10-13: se añadieron pruebas unitarias del mini-mapa, la tira de rincones y los chips de rincones del feed, cubriendo estados de carga/errores y asegurando la accesibilidad del panel derecho y filtros para sostener la cobertura >85%.
 
 Feature 4.2 Descubrimiento avanzado
 

--- a/frontend/tests/components/community/corners/CornersMiniMap.test.tsx
+++ b/frontend/tests/components/community/corners/CornersMiniMap.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CornersMiniMap } from '@src/components/community/corners/CornersMiniMap'
+import styles from '@src/components/community/corners/CornersMiniMap.module.scss'
+
+import { renderWithProviders } from '../../../test-utils'
+
+const useCornersMapMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@src/hooks/api/useCornersMap', () => ({
+  useCornersMap: useCornersMapMock,
+}))
+
+describe('CornersMiniMap', () => {
+  beforeEach(() => {
+    useCornersMapMock.mockReset()
+  })
+
+  test('renders loader state while the map data is loading', () => {
+    useCornersMapMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    })
+
+    const { container } = renderWithProviders(<CornersMiniMap />)
+
+    const map = container.querySelector(`.${styles.map}`)
+    expect(map).toBeInTheDocument()
+    expect(map).toHaveClass(styles.loading)
+
+    const loader = container.querySelector(`.${styles.loader}`)
+    expect(loader).toBeInTheDocument()
+  })
+
+  test('shows an error message when the map request fails', () => {
+    useCornersMapMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    })
+
+    renderWithProviders(<CornersMiniMap />)
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveTextContent('community.feed.cornersMap.error')
+  })
+
+  test('renders corner pins, description and footer when data is available', () => {
+    useCornersMapMock.mockReturnValue({
+      data: {
+        description: 'Mapa de actividad de la comunidad',
+        pins: [
+          { id: 'pin-1', status: 'quiet', x: 12, y: 34 },
+          { id: 'pin-2', status: 'active', x: 65, y: 22 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    })
+
+    const { container } = renderWithProviders(<CornersMiniMap />)
+
+    expect(
+      screen.getByText('Mapa de actividad de la comunidad')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('community.feed.cornersMap.footer')
+    ).toBeInTheDocument()
+
+    const nearbyButton = screen.getByRole('button', {
+      name: 'community.feed.cornersMap.actions.nearby',
+    })
+    expect(nearbyButton).toBeInTheDocument()
+
+    const pins = Array.from(container.querySelectorAll(`.${styles.pin}`))
+    expect(pins).toHaveLength(2)
+
+    const quietPin = pins.find((pin) => pin.classList.contains(styles.pinQuiet))
+    expect(quietPin).toHaveStyle({ left: '12%', top: '34%' })
+
+    const activePin = pins.find(
+      (pin) => !pin.classList.contains(styles.pinQuiet)
+    )
+    expect(activePin).toHaveStyle({ left: '65%', top: '22%' })
+  })
+})

--- a/frontend/tests/components/community/corners/CornersStrip.test.tsx
+++ b/frontend/tests/components/community/corners/CornersStrip.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CornersStrip } from '@src/components/community/corners/CornersStrip'
+import styles from '@src/components/community/corners/CornersStrip.module.scss'
+
+import { renderWithProviders } from '../../../test-utils'
+
+const useNearbyCornersMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@src/hooks/api/useNearbyCorners', () => ({
+  useNearbyCorners: useNearbyCornersMock,
+}))
+
+const mockCorners = [
+  {
+    id: 'corner-1',
+    name: 'Rincón Centro',
+    distanceKm: 1.25,
+    imageUrl: 'https://example.com/corner-1.png',
+    activityLabel: '32 actividades esta semana',
+  },
+  {
+    id: 'corner-2',
+    name: 'Rincón Norte',
+    distanceKm: 0.4,
+    imageUrl: 'https://example.com/corner-2.png',
+    activityLabel: 'Sin número en la etiqueta',
+  },
+  {
+    id: 'corner-3',
+    name: 'Rincón Sur',
+    distanceKm: 5.8,
+    imageUrl: 'https://example.com/corner-3.png',
+    activityLabel: null,
+  },
+]
+
+describe('CornersStrip', () => {
+  beforeEach(() => {
+    useNearbyCornersMock.mockReset()
+  })
+
+  test('renders skeleton cards while loading data', () => {
+    useNearbyCornersMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    })
+
+    const { container } = renderWithProviders(<CornersStrip />)
+
+    const skeletons = container.querySelectorAll(`.${styles.skeleton}`)
+    expect(skeletons).toHaveLength(4)
+  })
+
+  test('shows error message when the request fails', () => {
+    useNearbyCornersMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    })
+
+    renderWithProviders(<CornersStrip />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'community.feed.corners.error'
+    )
+  })
+
+  test('shows empty state when there are no nearby corners', () => {
+    useNearbyCornersMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    })
+
+    renderWithProviders(<CornersStrip />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'community.feed.corners.empty'
+    )
+  })
+
+  test('renders the list of corners with badges and fallback image handling', () => {
+    useNearbyCornersMock.mockReturnValue({
+      data: mockCorners,
+      isLoading: false,
+      isError: false,
+    })
+
+    const { container } = renderWithProviders(<CornersStrip />)
+
+    const region = screen.getByRole('region', {
+      name: 'community.feed.corners.title',
+    })
+    expect(region).toBeInTheDocument()
+
+    const viewMapLink = screen.getByRole('button', {
+      name: 'community.feed.corners.viewMap',
+    })
+    expect(viewMapLink).toHaveAttribute('href', '/map')
+
+    const cards = screen.getAllByRole('article')
+    expect(cards).toHaveLength(mockCorners.length)
+
+    expect(within(cards[0]).getByText('Rincón Centro')).toBeInTheDocument()
+    const badge = within(cards[0]).getByText('32')
+    expect(badge).toHaveAttribute('aria-label', '32 actividades esta semana')
+
+    const images = container.querySelectorAll('img')
+    fireEvent.error(images[0])
+    expect(images[0].src).toContain('corner-fallback')
+
+    const activityBadges = container.querySelectorAll(`.${styles.activity}`)
+    expect(activityBadges).toHaveLength(1)
+  })
+})

--- a/frontend/tests/components/feed/ActivityBar.test.tsx
+++ b/frontend/tests/components/feed/ActivityBar.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ActivityBar } from '@src/components/feed/ActivityBar'
+import styles from '@src/components/feed/ActivityBar.module.scss'
+
+import { renderWithProviders } from '../../test-utils'
+
+const useActivityMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@src/hooks/api/useActivity', () => ({
+  useActivity: useActivityMock,
+}))
+
+describe('ActivityBar', () => {
+  beforeEach(() => {
+    useActivityMock.mockReset()
+  })
+
+  test('renders an empty bar when there is no activity', () => {
+    useActivityMock.mockReturnValue({ data: undefined })
+
+    const { container } = renderWithProviders(<ActivityBar />)
+
+    const bar = container.querySelector(`.${styles.bar}`)
+    expect(bar).toBeInTheDocument()
+    expect(bar?.children).toHaveLength(0)
+  })
+
+  test('renders user avatars and names from activity data', () => {
+    useActivityMock.mockReturnValue({
+      data: [
+        { id: '1', user: 'Ana', avatar: 'https://example.com/ana.png' },
+        { id: '2', user: 'Luis', avatar: 'https://example.com/luis.png' },
+      ],
+    })
+
+    renderWithProviders(<ActivityBar />)
+
+    expect(screen.getByAltText('Ana')).toHaveAttribute(
+      'src',
+      'https://example.com/ana.png'
+    )
+    expect(screen.getByText('Luis')).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/components/feed/CornerChip.test.tsx
+++ b/frontend/tests/components/feed/CornerChip.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { CornerChip } from '@src/components/feed/CornerChip'
+
+import { renderWithProviders } from '../../test-utils'
+
+describe('CornerChip', () => {
+  const corner = { id: 'corner-1', name: 'Rincón Centro' }
+
+  test('renders the corner name with the default class name', () => {
+    renderWithProviders(<CornerChip corner={corner} />)
+
+    const button = screen.getByRole('button', {
+      name: 'community.feed.cornerChip.ariaLabel',
+    })
+
+    expect(button).toHaveTextContent('Rincón Centro')
+  })
+
+  test('merges custom class names and triggers click handler', () => {
+    const onClick = vi.fn()
+
+    renderWithProviders(
+      <CornerChip corner={corner} className="highlight" onClick={onClick} />
+    )
+
+    const button = screen.getByRole('button', {
+      name: 'community.feed.cornerChip.ariaLabel',
+    })
+
+    expect(button).toHaveClass('highlight')
+
+    fireEvent.click(button)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/tests/components/feed/FeedList.test.tsx
+++ b/frontend/tests/components/feed/FeedList.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { FeedList } from '@src/components/feed/FeedList'
+import type { FeedItem } from '@src/components/feed/FeedItem.types'
+
+import { renderWithProviders } from '../../test-utils'
+
+const mocks = vi.hoisted(() => {
+  return {
+    bookCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-book-${item.id}`} />
+    )),
+    swapCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-swap-${item.id}`} />
+    )),
+    saleCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-sale-${item.id}`} />
+    )),
+    seekingCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-seeking-${item.id}`} />
+    )),
+    reviewCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-review-${item.id}`} />
+    )),
+    eventCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-event-${item.id}`} />
+    )),
+    houseCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-house-${item.id}`} />
+    )),
+    peopleCardMock: vi.fn(({ item }: { item: FeedItem }) => (
+      <div data-testid={`card-person-${item.id}`} />
+    )),
+  }
+})
+
+vi.mock('@src/components/feed/cards/BookFeedCard', () => ({
+  BookFeedCard: mocks.bookCardMock,
+}))
+vi.mock('@src/components/feed/cards/SwapProposalCard', () => ({
+  SwapProposalCard: mocks.swapCardMock,
+}))
+vi.mock('@src/components/feed/cards/ForSaleCard', () => ({
+  ForSaleCard: mocks.saleCardMock,
+}))
+vi.mock('@src/components/feed/cards/SeekingCard', () => ({
+  SeekingCard: mocks.seekingCardMock,
+}))
+vi.mock('@src/components/feed/cards/ReviewCard', () => ({
+  ReviewCard: mocks.reviewCardMock,
+}))
+vi.mock('@src/components/feed/cards/EventCard', () => ({
+  EventCard: mocks.eventCardMock,
+}))
+vi.mock('@src/components/feed/cards/HouseCard', () => ({
+  HouseCard: mocks.houseCardMock,
+}))
+vi.mock('@src/components/feed/cards/PeopleCard', () => ({
+  PeopleCard: mocks.peopleCardMock,
+}))
+
+describe('FeedList', () => {
+  test('renders the appropriate card for each feed item type', () => {
+    const items: FeedItem[] = [
+      { id: 'book-1', type: 'book' } as FeedItem,
+      { id: 'swap-1', type: 'swap' } as FeedItem,
+      { id: 'sale-1', type: 'sale' } as FeedItem,
+      { id: 'seeking-1', type: 'seeking' } as FeedItem,
+      { id: 'review-1', type: 'review' } as FeedItem,
+      { id: 'event-1', type: 'event' } as FeedItem,
+      { id: 'house-1', type: 'house' } as FeedItem,
+      { id: 'person-1', type: 'person' } as FeedItem,
+    ]
+
+    const { queryByTestId } = renderWithProviders(<FeedList items={items} />)
+
+    expect(queryByTestId('card-book-book-1')).toBeInTheDocument()
+    expect(queryByTestId('card-swap-swap-1')).toBeInTheDocument()
+    expect(queryByTestId('card-sale-sale-1')).toBeInTheDocument()
+    expect(queryByTestId('card-seeking-seeking-1')).toBeInTheDocument()
+    expect(queryByTestId('card-review-review-1')).toBeInTheDocument()
+    expect(queryByTestId('card-event-event-1')).toBeInTheDocument()
+    expect(queryByTestId('card-house-house-1')).toBeInTheDocument()
+    expect(queryByTestId('card-person-person-1')).toBeInTheDocument()
+
+    const firstCall = mocks.bookCardMock.mock.calls.at(0)?.[0]
+    expect(firstCall?.item).toMatchObject({ id: 'book-1', type: 'book' })
+
+    expect(mocks.swapCardMock).toHaveBeenCalled()
+    expect(mocks.saleCardMock).toHaveBeenCalled()
+    expect(mocks.seekingCardMock).toHaveBeenCalled()
+    expect(mocks.reviewCardMock).toHaveBeenCalled()
+    expect(mocks.eventCardMock).toHaveBeenCalled()
+    expect(mocks.houseCardMock).toHaveBeenCalled()
+    expect(mocks.peopleCardMock).toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/components/feed/RightPanel.test.tsx
+++ b/frontend/tests/components/feed/RightPanel.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { RightPanel } from '@src/components/feed/RightPanel'
+import styles from '@src/components/feed/RightPanel.module.scss'
+
+import { renderWithProviders } from '../../test-utils'
+
+const useSuggestionsMock = vi.hoisted(() => vi.fn())
+const cornersMiniMapMock = vi.hoisted(() =>
+  vi.fn(() => <div data-testid="mini-map" />)
+)
+
+vi.mock('@components/community/corners/CornersMiniMap', () => ({
+  CornersMiniMap: cornersMiniMapMock,
+}))
+
+vi.mock('@src/hooks/api/useSuggestions', () => ({
+  useSuggestions: useSuggestionsMock,
+}))
+
+describe('RightPanel', () => {
+  beforeEach(() => {
+    useSuggestionsMock.mockReset()
+    cornersMiniMapMock.mockClear()
+  })
+
+  test('renders the suggestions heading and the mini map', () => {
+    useSuggestionsMock.mockReturnValue({ data: undefined })
+
+    const { container } = renderWithProviders(<RightPanel />)
+
+    expect(screen.getByTestId('mini-map')).toBeInTheDocument()
+
+    const heading = screen.getByRole('heading', {
+      name: 'community.feed.suggestions',
+      level: 2,
+    })
+    expect(heading).toBeInTheDocument()
+
+    const panel = container.querySelector(`.${styles.panel}`)
+    expect(panel).toBeInTheDocument()
+  })
+
+  test('lists user suggestions when data is available', () => {
+    useSuggestionsMock.mockReturnValue({
+      data: [
+        {
+          id: 'suggestion-1',
+          user: 'Clara',
+          avatar: 'https://example.com/clara.png',
+        },
+        {
+          id: 'suggestion-2',
+          user: 'Miguel',
+          avatar: 'https://example.com/miguel.png',
+        },
+      ],
+    })
+
+    renderWithProviders(<RightPanel />)
+
+    expect(screen.getByText('Clara')).toBeInTheDocument()
+    expect(screen.getByAltText('Miguel')).toHaveAttribute(
+      'src',
+      'https://example.com/miguel.png'
+    )
+  })
+})

--- a/frontend/tests/utils/cx.test.ts
+++ b/frontend/tests/utils/cx.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+import { cx } from '@src/utils/cx'
+
+describe('cx utility', () => {
+  test('combines string and number values while ignoring falsy entries', () => {
+    expect(cx('btn', '', 'primary', 0, 2)).toBe('btn primary 2')
+  })
+
+  test('flattens nested arrays of class values', () => {
+    expect(cx(['grid', ['md:grid-cols-2', ['lg:grid-cols-3']]])).toBe(
+      'grid md:grid-cols-2 lg:grid-cols-3'
+    )
+  })
+
+  test('includes object keys with truthy values only', () => {
+    expect(
+      cx({ active: true, disabled: false, hidden: 0 }, { focused: 1 })
+    ).toBe('active focused')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for CornersMiniMap and CornersStrip covering loading, error and populated states
- extend feed coverage with ActivityBar, CornerChip, FeedList, RightPanel, and cx utility scenarios
- document the additional coverage work in the backlog under the discovery epic

## Testing
- npm run test:frontend
- npm run test:backend *(fails: database service not available in CI container)*
- npm run format:backend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e12e7fbe18832eb13a11949ed4cd18