### PR TITLE
Refactor publish corner location flow and boost coverage

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -71,6 +71,7 @@ Feature 2.1 Alta y gestión de RdL
   - Actualización 2025-10-16: se implementó el modal multipaso "Crear Rincón" con stepper, validación inline, consentimiento explícito y flujo de borrador/publicación reutilizando los componentes compartidos de publicación. Se agregó MSW (201/422) y pruebas de navegación/errores. Falta enlazar con backend real y lógica de moderación para considerarlo completado.
   - Actualización 2025-10-20: el paso de dirección ahora ofrece autocompletado con vista previa en mapa, fija latitud/longitud automáticamente y mantiene la preferencia de visibilidad sin exponer coordenadas manuales.
   - Actualización 2025-10-21: se completaron pruebas unitarias del servicio de geocodificación, handlers MSW y del paso de ubicación (autocomplete, errores, reinicio), recuperando la cobertura de ramas >85% y asegurando la regresión de privacidad.
+  - Actualización 2025-10-22: se modularizó el paso de ubicación (inputs, carga de foto y consentimiento) y el modal completo via hooks dedicados para simplificar mantenimiento, agregando pruebas unitarias de navegación, errores y reinicio que elevan la cobertura de ramas y validan escenarios de teclado.
 - [ ] S-2.2 Estados de RdL (Activo / Pausa / Observación) (Should, E2; BR-12)
   - Éxito: pausa oculta de resultados temporalmente.
 - [ ] S-2.3 Verificación ligera de anfitrión (Could, E3; BR-14)
@@ -125,6 +126,7 @@ Feature 4.1 Mapa y listados
   - Actualización 2025-10-14: se sustituyó la aproximación lineal de distancia por cálculos geodésicos Haversine para centrar el mapa y se modernizaron los estilos con sintaxis `rgb(var() / α)` en los componentes vinculados.
   - Actualización 2025-10-15: se factorizaron los cálculos de geocercas con la utilidad Haversine reutilizable, se ajustó la bbox inicial del mapa y se añadieron pruebas unitarias dedicadas.
   - Actualización 2025-10-19: el modal de alta de Rincones ahora captura la dirección exacta (calle, número, opcionales) y coordenadas, almacena la preferencia de visibilidad (exacta/aproximada) y actualiza la confirmación de privacidad. Se adaptaron payloads/mock MSW, validaciones y pruebas para reflejar la política de logística y visualización.
+  - Actualización 2025-10-22: se robusteció el cálculo de estados vacíos en el mapa considerando capas visibles y actividad reciente, evitando falsos positivos cuando se ocultan capas; se añadieron pruebas unitarias del paso de ubicación para sostener la cobertura mínima requerida.
 
 Feature 4.2 Descubrimiento avanzado
 

--- a/frontend/src/components/publish/PublishCornerModal/PublishCornerModal.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/PublishCornerModal.tsx
@@ -1,33 +1,16 @@
-import { PublishCornerPayload } from '@api/community/corners.types'
 import {
   PublishModal,
-  PublishModalAction,
   PublishModalActions,
   PublishStepper,
 } from '@components/publish/shared'
-import { useCreateCorner } from '@hooks/api/useCreateCorner'
-import { useFocusTrap } from '@hooks/useFocusTrap'
-import { usePublishDraft } from '@hooks/usePublishDraft'
-import { stripDraftMeta } from '@utils/drafts'
-import isEqual from 'lodash/isEqual'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'react-toastify'
 
 import { DetailsStep } from './components/DetailsStep'
 import { LocationStep } from './components/LocationStep'
 import { ReviewStep } from './components/ReviewStep'
-import {
-  STORAGE_KEY,
-  initialState,
-  stepOrder,
-  toSerializableDraft,
-} from './PublishCornerModal.constants'
 import styles from './PublishCornerModal.module.scss'
-import {
-  PublishCornerDraftState,
-  PublishCornerFormState,
-} from './PublishCornerModal.types'
+import { useCornerForm } from './useCornerForm'
 
 type PublishCornerModalProps = {
   isOpen: boolean
@@ -35,371 +18,26 @@ type PublishCornerModalProps = {
   onCreated: (cornerId: string) => void
 }
 
-const sanitizeDraft = (
-  draft: PublishCornerDraftState | null
-): PublishCornerFormState => {
-  if (!draft) return initialState
-  return {
-    ...initialState,
-    ...draft,
-    photo: draft.photo ? { ...draft.photo } : null,
-  }
-}
-
-const useBodyScrollLock = (isOpen: boolean) => {
-  useEffect(() => {
-    if (!isOpen) return
-    const original = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = original
-    }
-  }, [isOpen])
-}
-
-const useCornerDraft = () =>
-  usePublishDraft<PublishCornerDraftState>({ storageKey: STORAGE_KEY })
-
 export const PublishCornerModal: React.FC<PublishCornerModalProps> = ({
   isOpen,
   onClose,
   onCreated,
 }) => {
   const { t } = useTranslation()
-  const { draft: storedDraft, saveNow, scheduleSave, clear } = useCornerDraft()
-  const draft = useMemo(() => stripDraftMeta(storedDraft), [storedDraft])
-  const [state, setState] = useState<PublishCornerFormState>(initialState)
-  const [autosaveEnabled, setAutosaveEnabled] = useState(true)
-  const [initialized, setInitialized] = useState(false)
-  const modalRef = useRef<HTMLDivElement>(null)
 
-  const { mutateAsync, isPending } = useCreateCorner()
-
-  const baselineDraft = useMemo(
-    () => draft ?? toSerializableDraft(initialState),
-    [draft]
-  )
-  const serializableState = useMemo(() => toSerializableDraft(state), [state])
-
-  useEffect(() => {
-    if (!isOpen) {
-      setInitialized(false)
-      setAutosaveEnabled(true)
-      return
-    }
-    if (initialized) return
-    setInitialized(true)
-    setState(sanitizeDraft(draft))
-  }, [draft, initialized, isOpen])
-
-  useEffect(() => {
-    if (!isOpen || !autosaveEnabled) return
-    if (isEqual(serializableState, baselineDraft)) return
-    scheduleSave(serializableState)
-  }, [autosaveEnabled, baselineDraft, isOpen, scheduleSave, serializableState])
-
-  const updateState = useCallback((update: Partial<PublishCornerFormState>) => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({ ...prev, ...update }))
-  }, [])
-
-  const closeWithConfirmation = useCallback(() => {
-    const hasChanges = !isEqual(serializableState, baselineDraft)
-    if (hasChanges) {
-      const confirmed = window.confirm(t('publishCorner.confirmClose'))
-      if (!confirmed) {
-        return
-      }
-    }
-    onClose()
-  }, [baselineDraft, onClose, serializableState, t])
-
-  useFocusTrap({
-    containerRef: modalRef,
-    active: isOpen,
-    onEscape: closeWithConfirmation,
-  })
-  useBodyScrollLock(isOpen)
-
-  useEffect(() => {
-    if (!isOpen) return
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!isEqual(serializableState, baselineDraft)) {
-        event.preventDefault()
-        event.returnValue = ''
-      }
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-    }
-  }, [baselineDraft, isOpen, serializableState])
-
-  const handleSaveDraft = useCallback(() => {
-    saveNow(serializableState)
-    toast.success(t('publishCorner.draftSaved'))
-  }, [saveNow, serializableState, t])
-
-  const handlePhotoSelect = useCallback(
-    (files: FileList | null) => {
-      if (!files || files.length === 0) return
-      const file = files[0]
-      const reader = new FileReader()
-      reader.onload = () => {
-        updateState({
-          photo: {
-            id: `${file.name}-${Date.now()}`,
-            url: String(reader.result),
-            alt: file.name,
-          },
-        })
-      }
-      reader.onerror = () => {
-        toast.error(t('publishCorner.errors.photoRead'))
-      }
-      reader.readAsDataURL(file)
-    },
-    [t, updateState]
-  )
-
-  const handleRemovePhoto = useCallback(() => {
-    updateState({ photo: null })
-  }, [updateState])
-
-  const detailsErrors = useMemo(() => {
-    const errors: { [key: string]: string } = {}
-    if (!state.name.trim()) {
-      errors.name = t('publishCorner.errors.name')
-    }
-    if (!state.hostAlias.trim()) {
-      errors.hostAlias = t('publishCorner.errors.hostAlias')
-    }
-    if (!state.internalContact.trim()) {
-      errors.internalContact = t('publishCorner.errors.internalContact')
-    }
-    return errors
-  }, [state.hostAlias, state.internalContact, state.name, t])
-
-  const locationErrors = useMemo(() => {
-    const errors: { [key: string]: string } = {}
-
-    if (!state.street.trim()) {
-      errors.street = t('publishCorner.errors.street')
-    }
-
-    if (!state.number.trim()) {
-      errors.number = t('publishCorner.errors.number')
-    }
-
-    const latitude = Number(state.latitude)
-    const longitude = Number(state.longitude)
-
-    if (!state.addressSearch.trim()) {
-      errors.addressSearch = t('publishCorner.errors.addressSearch')
-    } else if (
-      !state.latitude.trim() ||
-      Number.isNaN(latitude) ||
-      !state.longitude.trim() ||
-      Number.isNaN(longitude)
-    ) {
-      errors.addressSearch = t('publishCorner.errors.addressSearch')
-    } else if (latitude < -90 || latitude > 90) {
-      errors.addressSearch = t('publishCorner.errors.latitudeRange')
-    } else if (longitude < -180 || longitude > 180) {
-      errors.addressSearch = t('publishCorner.errors.longitudeRange')
-    }
-
-    if (!state.photo) {
-      errors.photo = t('publishCorner.errors.photo')
-    }
-
-    if (!state.consent) {
-      errors.consent = t('publishCorner.errors.consent')
-    }
-
-    return errors
-  }, [
-    state.addressSearch,
-    state.consent,
-    state.latitude,
-    state.longitude,
-    state.number,
-    state.photo,
-    state.street,
-    t,
-  ])
-
-  const canProceedDetails = useMemo(
-    () => Object.keys(detailsErrors).length === 0,
-    [detailsErrors]
-  )
-
-  const canProceedLocation = useMemo(
-    () =>
-      Object.keys(locationErrors).filter((key) => key !== 'consent').length ===
-      0,
-    [locationErrors]
-  )
-
-  const publishDisabled = useMemo(
-    () =>
-      isPending ||
-      !state.consent ||
-      !state.photo ||
-      !state.addressSearch.trim() ||
-      !state.street.trim() ||
-      !state.number.trim() ||
-      !state.latitude.trim() ||
-      !state.longitude.trim() ||
-      !canProceedDetails ||
-      !canProceedLocation,
-    [
-      canProceedDetails,
-      canProceedLocation,
-      isPending,
-      state.addressSearch,
-      state.latitude,
-      state.longitude,
-      state.consent,
-      state.photo,
-      state.number,
-      state.street,
-    ]
-  )
-
-  const handleNext = useCallback(() => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({
-      ...prev,
-      step: prev.step === 'details' ? 'location' : 'review',
-    }))
-  }, [])
-
-  const handleBack = useCallback(() => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({
-      ...prev,
-      step: prev.step === 'review' ? 'location' : 'details',
-    }))
-  }, [])
-
-  const handlePublish = useCallback(async () => {
-    if (!state.photo) return
-    const payload: PublishCornerPayload = {
-      name: state.name,
-      scope: state.scope,
-      hostAlias: state.hostAlias,
-      internalContact: state.internalContact,
-      rules: state.rules || undefined,
-      schedule: state.schedule || undefined,
-      location: {
-        address: {
-          street: state.street.trim(),
-          number: state.number.trim(),
-          unit: state.unit.trim() || undefined,
-          postalCode: state.postalCode.trim() || undefined,
-        },
-        coordinates: {
-          latitude: Number(state.latitude),
-          longitude: Number(state.longitude),
-        },
-        visibilityPreference: state.visibilityPreference,
-      },
-      consent: state.consent,
-      photo: {
-        id: state.photo.id,
-        url: state.photo.url,
-      },
-      status: state.status,
-      draft: false,
-    }
-
-    try {
-      const created = await mutateAsync(payload)
-      toast.success(t('publishCorner.published'))
-      clear()
-      setState(initialState)
-      setAutosaveEnabled(true)
-      onCreated(created.id)
-      onClose()
-    } catch {
-      toast.error(t('publishCorner.errors.publish'))
-    }
-  }, [clear, mutateAsync, onClose, onCreated, state, t])
-
-  const stepperSteps = useMemo(
-    () =>
-      stepOrder.map((step) => ({
-        id: step,
-        label: t(`publishCorner.steps.${step}.title`),
-        description: t(`publishCorner.steps.${step}.description`),
-      })),
-    [t]
-  )
-
-  const leftActions = useMemo<PublishModalAction[]>(
-    () => [
-      {
-        label: t('publishCorner.actions.cancel'),
-        onClick: closeWithConfirmation,
-        variant: 'secondary',
-      },
-      {
-        label: t('publishCorner.actions.saveDraft'),
-        onClick: handleSaveDraft,
-        variant: 'secondary',
-      },
-    ],
-    [closeWithConfirmation, handleSaveDraft, t]
-  )
-
-  const rightActions = useMemo<PublishModalAction[]>(() => {
-    const actions: PublishModalAction[] = []
-    if (state.step !== 'details') {
-      actions.push({
-        label: t('publishCorner.actions.back'),
-        onClick: handleBack,
-        variant: 'secondary',
-      })
-    }
-
-    if (state.step === 'details') {
-      actions.push({
-        label: t('publishCorner.actions.next'),
-        onClick: handleNext,
-        variant: 'primary',
-        disabled: !canProceedDetails,
-      })
-    } else if (state.step === 'location') {
-      actions.push({
-        label: t('publishCorner.actions.next'),
-        onClick: handleNext,
-        variant: 'primary',
-        disabled: !canProceedLocation,
-      })
-    } else {
-      actions.push({
-        label: isPending
-          ? t('publishCorner.actions.publishing')
-          : t('publishCorner.actions.publish'),
-        onClick: handlePublish,
-        variant: 'primary',
-        disabled: publishDisabled,
-      })
-    }
-
-    return actions
-  }, [
-    canProceedDetails,
-    canProceedLocation,
-    handleBack,
-    handleNext,
-    handlePublish,
-    isPending,
-    publishDisabled,
-    state.step,
-    t,
-  ])
+  const {
+    modalRef,
+    state,
+    updateState,
+    detailsErrors,
+    locationErrors,
+    stepperSteps,
+    leftActions,
+    rightActions,
+    handlePhotoSelect,
+    handleRemovePhoto,
+    closeWithConfirmation,
+  } = useCornerForm({ isOpen, onClose, onCreated, t })
 
   if (!isOpen) return null
 

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationConsentSection.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationConsentSection.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import styles from '../PublishCornerModal.module.scss'
+import type { PublishCornerFormState } from '../PublishCornerModal.types'
+
+import type { LocationStepErrors } from './LocationStep.types'
+
+type LocationConsentSectionProps = {
+  t: (key: string) => string
+  state: PublishCornerFormState
+  errors: LocationStepErrors
+  onChange: (update: Partial<PublishCornerFormState>) => void
+}
+
+export const LocationConsentSection: React.FC<LocationConsentSectionProps> = ({
+  t,
+  state,
+  errors,
+  onChange,
+}) => {
+  return (
+    <>
+      <div className={styles.consentRow}>
+        <input
+          id="corner-consent"
+          type="checkbox"
+          checked={state.consent}
+          onChange={(event) => onChange({ consent: event.target.checked })}
+        />
+        <label htmlFor="corner-consent">
+          {t('publishCorner.fields.consent')}
+        </label>
+      </div>
+      {errors.consent ? (
+        <span className={styles.error} role="alert">
+          {errors.consent}
+        </span>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationFieldsGroup.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationFieldsGroup.tsx
@@ -1,0 +1,60 @@
+import { PublishTextField } from '@components/publish/shared'
+import React from 'react'
+
+import styles from '../PublishCornerModal.module.scss'
+import type { PublishCornerFormState } from '../PublishCornerModal.types'
+
+import type { LocationStepErrors } from './LocationStep.types'
+
+type LocationFieldsGroupProps = {
+  t: (key: string) => string
+  state: PublishCornerFormState
+  errors: LocationStepErrors
+  disabled: boolean
+  onChange: (update: Partial<PublishCornerFormState>) => void
+}
+
+export const LocationFieldsGroup: React.FC<LocationFieldsGroupProps> = ({
+  t,
+  state,
+  errors,
+  disabled,
+  onChange,
+}) => {
+  return (
+    <div className={styles.gridTwo}>
+      <PublishTextField
+        id="corner-street"
+        label={t('publishCorner.fields.street')}
+        value={state.street}
+        onChange={(event) => onChange({ street: event.target.value })}
+        error={disabled ? undefined : errors.street}
+        required
+        disabled={disabled}
+      />
+      <PublishTextField
+        id="corner-number"
+        label={t('publishCorner.fields.number')}
+        value={state.number}
+        onChange={(event) => onChange({ number: event.target.value })}
+        error={disabled ? undefined : errors.number}
+        required
+        disabled={disabled}
+      />
+      <PublishTextField
+        id="corner-unit"
+        label={t('publishCorner.fields.unit')}
+        value={state.unit}
+        onChange={(event) => onChange({ unit: event.target.value })}
+        disabled={disabled}
+      />
+      <PublishTextField
+        id="corner-postal-code"
+        label={t('publishCorner.fields.postalCode')}
+        value={state.postalCode}
+        onChange={(event) => onChange({ postalCode: event.target.value })}
+        disabled={disabled}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationPhotoUpload.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationPhotoUpload.tsx
@@ -1,0 +1,39 @@
+import { PublishFileUpload } from '@components/publish/shared'
+import React from 'react'
+
+import type { PublishCornerFormState } from '../PublishCornerModal.types'
+
+import type { LocationStepErrors } from './LocationStep.types'
+
+type LocationPhotoUploadProps = {
+  t: (key: string) => string
+  state: PublishCornerFormState
+  errors: LocationStepErrors
+  onPhotoSelect: (files: FileList | null) => void
+  onRemovePhoto: () => void
+}
+
+export const LocationPhotoUpload: React.FC<LocationPhotoUploadProps> = ({
+  t,
+  state,
+  errors,
+  onPhotoSelect,
+  onRemovePhoto,
+}) => {
+  return (
+    <PublishFileUpload
+      id="corner-photo"
+      label={t('publishCorner.fields.photo')}
+      buttonLabel={t('publishCorner.fields.photoCta')}
+      hint={t('publishCorner.fields.photoHint') ?? undefined}
+      accept="image/*"
+      multiple={false}
+      previews={state.photo ? [state.photo] : []}
+      onFilesSelected={onPhotoSelect}
+      onDropFiles={(files) => onPhotoSelect(files)}
+      onRemoveFile={() => onRemovePhoto()}
+      removeLabel={t('publishCorner.fields.photoRemove') ?? ''}
+      error={errors.photo}
+    />
+  )
+}

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationSearchSection.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationSearchSection.tsx
@@ -1,0 +1,190 @@
+import { PublishTextField } from '@components/publish/shared'
+import React from 'react'
+import { CircleMarker, MapContainer, TileLayer } from 'react-leaflet'
+
+import type { GeocodingSuggestion } from '@src/api/map/geocoding.types'
+import { cx } from '@src/utils/cx'
+
+import styles from '../PublishCornerModal.module.scss'
+
+import type { LocationStepErrors } from './LocationStep.types'
+
+type LocationSearchSectionProps = {
+  t: (key: string) => string
+  errors: LocationStepErrors
+  searchValue: string
+  inputRef: React.RefObject<HTMLInputElement | null>
+  onSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onFocus: () => void
+  onBlur: () => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  disabled: boolean
+  showSuggestions: boolean
+  suggestions: GeocodingSuggestion[]
+  suggestionListId: string
+  activeSuggestionIndex: number
+  onSuggestionMouseDown: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    suggestion: GeocodingSuggestion
+  ) => void
+  hasSelection: boolean
+  hasNoResults: boolean
+  isSearching: boolean
+  searchError: string | null
+  onChangeAddress: () => void
+  mapCenter: [number, number] | null
+}
+
+export const LocationSearchSection: React.FC<LocationSearchSectionProps> = ({
+  t,
+  errors,
+  searchValue,
+  inputRef,
+  onSearchChange,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  disabled,
+  showSuggestions,
+  suggestions,
+  suggestionListId,
+  activeSuggestionIndex,
+  onSuggestionMouseDown,
+  hasSelection,
+  hasNoResults,
+  isSearching,
+  searchError,
+  onChangeAddress,
+  mapCenter,
+}) => {
+  return (
+    <div className={styles.addressSection}>
+      <PublishTextField
+        ref={inputRef}
+        id="corner-address-search"
+        label={t('publishCorner.fields.addressSearch')}
+        placeholder={t('publishCorner.fields.addressSearchPlaceholder') ?? ''}
+        value={searchValue}
+        onChange={onSearchChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        error={errors.addressSearch}
+        autoComplete="off"
+        aria-autocomplete="list"
+        aria-controls={suggestions.length > 0 ? suggestionListId : undefined}
+        aria-expanded={showSuggestions && suggestions.length > 0}
+        aria-haspopup="listbox"
+        aria-activedescendant={
+          activeSuggestionIndex >= 0
+            ? `${suggestionListId}-${suggestions[activeSuggestionIndex]?.id}`
+            : undefined
+        }
+      />
+
+      {!hasSelection ? (
+        <p className={styles.searchHint}>
+          {t('publishCorner.fields.addressSearchHint')}
+        </p>
+      ) : null}
+
+      {showSuggestions && suggestions.length > 0 ? (
+        <ul
+          id={suggestionListId}
+          role="listbox"
+          className={styles.suggestionsList}
+        >
+          {suggestions.map((suggestion, index) => {
+            const isActive = index === activeSuggestionIndex
+            return (
+              <li key={suggestion.id} role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  id={`${suggestionListId}-${suggestion.id}`}
+                  aria-selected={isActive}
+                  className={cx(
+                    styles.suggestionButton,
+                    isActive ? styles.suggestionButtonActive : ''
+                  )}
+                  onMouseDown={(event) =>
+                    onSuggestionMouseDown(event, suggestion)
+                  }
+                >
+                  <span className={styles.suggestionPrimary}>
+                    {suggestion.label}
+                  </span>
+                  {suggestion.secondaryLabel ? (
+                    <span className={styles.suggestionSecondary}>
+                      {suggestion.secondaryLabel}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+
+      {isSearching ? (
+        <p className={styles.searchStatus} role="status">
+          {t('publishCorner.location.searching')}
+        </p>
+      ) : null}
+
+      {searchError ? (
+        <p className={styles.searchStatusError} role="alert">
+          {searchError}
+        </p>
+      ) : null}
+
+      {hasNoResults ? (
+        <p className={styles.searchStatus} role="status">
+          {t('publishCorner.errors.addressNoResults')}
+        </p>
+      ) : null}
+
+      {hasSelection ? (
+        <div className={styles.mapPreview}>
+          <div className={styles.mapPreviewHeader}>
+            <span>{t('publishCorner.fields.mapPreviewTitle')}</span>
+            <button
+              type="button"
+              className={styles.changeAddressButton}
+              onClick={onChangeAddress}
+            >
+              {t('publishCorner.actions.changeAddress')}
+            </button>
+          </div>
+          {mapCenter ? (
+            <MapContainer
+              center={mapCenter}
+              zoom={16}
+              className={styles.mapPreviewCanvas}
+              scrollWheelZoom={false}
+              doubleClickZoom={false}
+              dragging={false}
+              zoomControl={false}
+            >
+              <TileLayer
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                attribution="&copy; OpenStreetMap contributors"
+              />
+              <CircleMarker
+                center={mapCenter}
+                radius={10}
+                pathOptions={{
+                  color: 'var(--primary-600, #2d57ff)',
+                  fillColor: 'var(--primary-600, #2d57ff)',
+                  fillOpacity: 0.85,
+                  weight: 2,
+                }}
+              />
+            </MapContainer>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationStep.tsx
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationStep.tsx
@@ -1,33 +1,17 @@
-import {
-  PublishFileUpload,
-  PublishSegmentedControl,
-  PublishTextField,
-} from '@components/publish/shared'
-import { TFunction } from 'i18next'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { CircleMarker, MapContainer, TileLayer } from 'react-leaflet'
-
-import { searchAddressSuggestions } from '@src/api/map/geocoding.service'
-import { GeocodingSuggestion } from '@src/api/map/geocoding.types'
-import { cx } from '@src/utils/cx'
+import { PublishSegmentedControl } from '@components/publish/shared'
+import React from 'react'
 
 import 'leaflet/dist/leaflet.css'
 
 import styles from '../PublishCornerModal.module.scss'
-import { PublishCornerFormState } from '../PublishCornerModal.types'
+import type { PublishCornerFormState } from '../PublishCornerModal.types'
 
-type LocationStepErrors = Partial<
-  Record<'addressSearch' | 'street' | 'number' | 'photo' | 'consent', string>
->
-
-type LocationStepProps = {
-  t: TFunction
-  state: PublishCornerFormState
-  errors: LocationStepErrors
-  onChange: (update: Partial<PublishCornerFormState>) => void
-  onPhotoSelect: (files: FileList | null) => void
-  onRemovePhoto: () => void
-}
+import { LocationConsentSection } from './LocationConsentSection'
+import { LocationFieldsGroup } from './LocationFieldsGroup'
+import { LocationPhotoUpload } from './LocationPhotoUpload'
+import { LocationSearchSection } from './LocationSearchSection'
+import type { LocationStepProps } from './LocationStep.types'
+import { useLocationSearch } from './useLocationSearch'
 
 const visibilityOptions = [
   {
@@ -45,8 +29,6 @@ const statusOptions = [
   { id: 'paused', labelKey: 'publishCorner.status.paused' },
 ] as const
 
-const SEARCH_DEBOUNCE_MS = 250
-
 export const LocationStep: React.FC<LocationStepProps> = ({
   t,
   state,
@@ -55,377 +37,58 @@ export const LocationStep: React.FC<LocationStepProps> = ({
   onPhotoSelect,
   onRemovePhoto,
 }) => {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [searchValue, setSearchValue] = useState(state.addressSearch)
-  const [suggestions, setSuggestions] = useState<GeocodingSuggestion[]>([])
-  const [isSearching, setIsSearching] = useState(false)
-  const [searchError, setSearchError] = useState<string | null>(null)
-  const [showSuggestions, setShowSuggestions] = useState(false)
-  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1)
-  const requestIdRef = useRef(0)
-  const blurTimeoutRef = useRef<number | null>(null)
-
-  const hasSelection = useMemo(
-    () => Boolean(state.latitude.trim() && state.longitude.trim()),
-    [state.latitude, state.longitude]
-  )
-  const hasSearchValue = searchValue.trim().length > 0
-  const mapCenter = useMemo(() => {
-    if (!hasSelection) return null
-    return [Number(state.latitude), Number(state.longitude)] as [number, number]
-  }, [hasSelection, state.latitude, state.longitude])
-
-  useEffect(() => {
-    if (!hasSelection) return
-    setSuggestions([])
-    setIsSearching(false)
-    setSearchError(null)
-    setShowSuggestions(false)
-    setSearchValue(state.addressSearch)
-  }, [hasSelection, state.addressSearch])
-
-  useEffect(() => {
-    return () => {
-      if (blurTimeoutRef.current) {
-        window.clearTimeout(blurTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    if (hasSelection) return
-
-    if (!hasSearchValue) {
-      setSuggestions([])
-      setIsSearching(false)
-      setSearchError(null)
-      setActiveSuggestionIndex(-1)
-      return
-    }
-
-    const timeout = window.setTimeout(async () => {
-      const requestId = requestIdRef.current + 1
-      requestIdRef.current = requestId
-      setIsSearching(true)
-
-      try {
-        const results = await searchAddressSuggestions(searchValue)
-        if (requestIdRef.current !== requestId) return
-        setSuggestions(results)
-        setSearchError(null)
-        setActiveSuggestionIndex(results.length > 0 ? 0 : -1)
-      } catch {
-        if (requestIdRef.current !== requestId) return
-        setSuggestions([])
-        setSearchError(t('publishCorner.errors.addressSearchFailed'))
-        setActiveSuggestionIndex(-1)
-      } finally {
-        if (requestIdRef.current === requestId) {
-          setIsSearching(false)
-        }
-      }
-    }, SEARCH_DEBOUNCE_MS)
-
-    return () => {
-      window.clearTimeout(timeout)
-    }
-  }, [hasSearchValue, hasSelection, searchValue, t])
-
-  const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value
-      setSearchValue(value)
-      setShowSuggestions(true)
-      setSearchError(null)
-      setActiveSuggestionIndex(-1)
-      onChange({
-        addressSearch: value,
-        latitude: '',
-        longitude: '',
-      })
-    },
-    [onChange]
-  )
-
-  const handleSelectSuggestion = useCallback(
-    (suggestion: GeocodingSuggestion) => {
-      onChange({
-        addressSearch: suggestion.label,
-        street: suggestion.street,
-        number: suggestion.number,
-        postalCode: suggestion.postalCode ?? '',
-        latitude: suggestion.coordinates.latitude.toString(),
-        longitude: suggestion.coordinates.longitude.toString(),
-      })
-      setSearchValue(suggestion.label)
-      setSuggestions([])
-      setShowSuggestions(false)
-      setSearchError(null)
-      setActiveSuggestionIndex(-1)
-    },
-    [onChange]
-  )
-
-  const handleSearchKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (!showSuggestions || suggestions.length === 0) return
-
-      if (event.key === 'ArrowDown') {
-        event.preventDefault()
-        setActiveSuggestionIndex((prev) =>
-          prev + 1 >= suggestions.length ? 0 : prev + 1
-        )
-        return
-      }
-
-      if (event.key === 'ArrowUp') {
-        event.preventDefault()
-        setActiveSuggestionIndex((prev) =>
-          prev - 1 < 0 ? suggestions.length - 1 : prev - 1
-        )
-        return
-      }
-
-      if (event.key === 'Enter') {
-        if (activeSuggestionIndex < 0) return
-        event.preventDefault()
-        handleSelectSuggestion(suggestions[activeSuggestionIndex])
-        return
-      }
-
-      if (event.key === 'Escape') {
-        setShowSuggestions(false)
-      }
-    },
-    [
-      activeSuggestionIndex,
-      handleSelectSuggestion,
-      showSuggestions,
-      suggestions,
-    ]
-  )
-
-  const handleInputFocus = useCallback(() => {
-    if (!hasSelection && suggestions.length > 0) {
-      setShowSuggestions(true)
-    }
-  }, [hasSelection, suggestions.length])
-
-  const handleInputBlur = useCallback(() => {
-    blurTimeoutRef.current = window.setTimeout(() => {
-      setShowSuggestions(false)
-    }, 150)
-  }, [])
-
-  const handleSuggestionMouseDown = useCallback(
-    (
-      event: React.MouseEvent<HTMLButtonElement>,
-      suggestion: GeocodingSuggestion
-    ) => {
-      event.preventDefault()
-      if (blurTimeoutRef.current) {
-        window.clearTimeout(blurTimeoutRef.current)
-        blurTimeoutRef.current = null
-      }
-      handleSelectSuggestion(suggestion)
-    },
-    [handleSelectSuggestion]
-  )
-
-  const handleChangeAddress = useCallback(() => {
-    setSearchValue('')
-    setSuggestions([])
-    setSearchError(null)
-    setShowSuggestions(false)
-    setActiveSuggestionIndex(-1)
-    onChange({
-      addressSearch: '',
-      street: '',
-      number: '',
-      unit: '',
-      postalCode: '',
-      latitude: '',
-      longitude: '',
-    })
-    window.setTimeout(() => {
-      inputRef.current?.focus()
-    }, 50)
-  }, [onChange])
-
-  const hasNoResults =
-    !isSearching &&
-    !searchError &&
-    showSuggestions &&
-    hasSearchValue &&
-    suggestions.length === 0
-
-  const suggestionListId = 'publish-corner-address-suggestions'
+  const {
+    inputRef,
+    searchValue,
+    hasSelection,
+    mapCenter,
+    showSuggestions,
+    suggestions,
+    isSearching,
+    searchError,
+    hasNoResults,
+    suggestionListId,
+    activeSuggestionIndex,
+    handleSearchChange,
+    handleSearchKeyDown,
+    handleInputFocus,
+    handleInputBlur,
+    handleSuggestionMouseDown,
+    handleChangeAddress,
+  } = useLocationSearch({ state, t, onChange })
 
   return (
     <div className={styles.stepLayout}>
-      <div className={styles.addressSection}>
-        <PublishTextField
-          ref={inputRef}
-          id="corner-address-search"
-          label={t('publishCorner.fields.addressSearch')}
-          placeholder={t('publishCorner.fields.addressSearchPlaceholder') ?? ''}
-          value={searchValue}
-          onChange={handleSearchChange}
-          onFocus={handleInputFocus}
-          onBlur={handleInputBlur}
-          onKeyDown={handleSearchKeyDown}
-          disabled={hasSelection}
-          error={errors.addressSearch}
-          autoComplete="off"
-          aria-autocomplete="list"
-          aria-controls={suggestions.length > 0 ? suggestionListId : undefined}
-          aria-expanded={showSuggestions && suggestions.length > 0}
-          aria-haspopup="listbox"
-          aria-activedescendant={
-            activeSuggestionIndex >= 0
-              ? `${suggestionListId}-${suggestions[activeSuggestionIndex]?.id}`
-              : undefined
-          }
-        />
+      <LocationSearchSection
+        t={t}
+        errors={errors}
+        searchValue={searchValue}
+        inputRef={inputRef}
+        onSearchChange={handleSearchChange}
+        onFocus={handleInputFocus}
+        onBlur={handleInputBlur}
+        onKeyDown={handleSearchKeyDown}
+        disabled={hasSelection}
+        showSuggestions={showSuggestions}
+        suggestions={suggestions}
+        suggestionListId={suggestionListId}
+        activeSuggestionIndex={activeSuggestionIndex}
+        onSuggestionMouseDown={handleSuggestionMouseDown}
+        hasSelection={hasSelection}
+        hasNoResults={hasNoResults}
+        isSearching={isSearching}
+        searchError={searchError}
+        onChangeAddress={handleChangeAddress}
+        mapCenter={mapCenter}
+      />
 
-        {!hasSelection ? (
-          <p className={styles.searchHint}>
-            {t('publishCorner.fields.addressSearchHint')}
-          </p>
-        ) : null}
-
-        {showSuggestions && suggestions.length > 0 ? (
-          <ul
-            id={suggestionListId}
-            role="listbox"
-            className={styles.suggestionsList}
-          >
-            {suggestions.map((suggestion, index) => {
-              const isActive = index === activeSuggestionIndex
-              return (
-                <li key={suggestion.id} role="presentation">
-                  <button
-                    type="button"
-                    role="option"
-                    id={`${suggestionListId}-${suggestion.id}`}
-                    aria-selected={isActive}
-                    className={cx(
-                      styles.suggestionButton,
-                      isActive ? styles.suggestionButtonActive : ''
-                    )}
-                    onMouseDown={(event) =>
-                      handleSuggestionMouseDown(event, suggestion)
-                    }
-                  >
-                    <span className={styles.suggestionPrimary}>
-                      {suggestion.label}
-                    </span>
-                    {suggestion.secondaryLabel ? (
-                      <span className={styles.suggestionSecondary}>
-                        {suggestion.secondaryLabel}
-                      </span>
-                    ) : null}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        ) : null}
-
-        {isSearching ? (
-          <p className={styles.searchStatus} role="status">
-            {t('publishCorner.location.searching')}
-          </p>
-        ) : null}
-
-        {searchError ? (
-          <p className={styles.searchStatusError} role="alert">
-            {searchError}
-          </p>
-        ) : null}
-
-        {hasNoResults ? (
-          <p className={styles.searchStatus} role="status">
-            {t('publishCorner.errors.addressNoResults')}
-          </p>
-        ) : null}
-
-        {hasSelection ? (
-          <div className={styles.mapPreview}>
-            <div className={styles.mapPreviewHeader}>
-              <span>{t('publishCorner.fields.mapPreviewTitle')}</span>
-              <button
-                type="button"
-                className={styles.changeAddressButton}
-                onClick={handleChangeAddress}
-              >
-                {t('publishCorner.actions.changeAddress')}
-              </button>
-            </div>
-            {mapCenter ? (
-              <MapContainer
-                center={mapCenter}
-                zoom={16}
-                className={styles.mapPreviewCanvas}
-                scrollWheelZoom={false}
-                doubleClickZoom={false}
-                dragging={false}
-                zoomControl={false}
-              >
-                <TileLayer
-                  url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                  attribution="&copy; OpenStreetMap contributors"
-                />
-                <CircleMarker
-                  center={mapCenter}
-                  radius={10}
-                  pathOptions={{
-                    color: 'var(--primary-600, #2d57ff)',
-                    fillColor: 'var(--primary-600, #2d57ff)',
-                    fillOpacity: 0.85,
-                    weight: 2,
-                  }}
-                />
-              </MapContainer>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-
-      <div className={styles.gridTwo}>
-        <PublishTextField
-          id="corner-street"
-          label={t('publishCorner.fields.street')}
-          value={state.street}
-          onChange={(event) => onChange({ street: event.target.value })}
-          error={hasSelection ? errors.street : undefined}
-          required
-          disabled={!hasSelection}
-        />
-        <PublishTextField
-          id="corner-number"
-          label={t('publishCorner.fields.number')}
-          value={state.number}
-          onChange={(event) => onChange({ number: event.target.value })}
-          error={hasSelection ? errors.number : undefined}
-          required
-          disabled={!hasSelection}
-        />
-        <PublishTextField
-          id="corner-unit"
-          label={t('publishCorner.fields.unit')}
-          value={state.unit}
-          onChange={(event) => onChange({ unit: event.target.value })}
-          disabled={!hasSelection}
-        />
-        <PublishTextField
-          id="corner-postal-code"
-          label={t('publishCorner.fields.postalCode')}
-          value={state.postalCode}
-          onChange={(event) => onChange({ postalCode: event.target.value })}
-          disabled={!hasSelection}
-        />
-      </div>
+      <LocationFieldsGroup
+        t={t}
+        state={state}
+        errors={errors}
+        disabled={!hasSelection}
+        onChange={onChange}
+      />
 
       <PublishSegmentedControl
         id="corner-visibility"
@@ -443,19 +106,12 @@ export const LocationStep: React.FC<LocationStepProps> = ({
         }
       />
 
-      <PublishFileUpload
-        id="corner-photo"
-        label={t('publishCorner.fields.photo')}
-        buttonLabel={t('publishCorner.fields.photoCta')}
-        hint={t('publishCorner.fields.photoHint') ?? undefined}
-        accept="image/*"
-        multiple={false}
-        previews={state.photo ? [state.photo] : []}
-        onFilesSelected={onPhotoSelect}
-        onDropFiles={(files) => onPhotoSelect(files)}
-        onRemoveFile={() => onRemovePhoto()}
-        removeLabel={t('publishCorner.fields.photoRemove') ?? ''}
-        error={errors.photo}
+      <LocationPhotoUpload
+        t={t}
+        state={state}
+        errors={errors}
+        onPhotoSelect={onPhotoSelect}
+        onRemovePhoto={onRemovePhoto}
       />
 
       <PublishSegmentedControl
@@ -471,22 +127,12 @@ export const LocationStep: React.FC<LocationStepProps> = ({
         }
       />
 
-      <div className={styles.consentRow}>
-        <input
-          id="corner-consent"
-          type="checkbox"
-          checked={state.consent}
-          onChange={(event) => onChange({ consent: event.target.checked })}
-        />
-        <label htmlFor="corner-consent">
-          {t('publishCorner.fields.consent')}
-        </label>
-      </div>
-      {errors.consent ? (
-        <span className={styles.error} role="alert">
-          {errors.consent}
-        </span>
-      ) : null}
+      <LocationConsentSection
+        t={t}
+        state={state}
+        errors={errors}
+        onChange={onChange}
+      />
     </div>
   )
 }

--- a/frontend/src/components/publish/PublishCornerModal/components/LocationStep.types.ts
+++ b/frontend/src/components/publish/PublishCornerModal/components/LocationStep.types.ts
@@ -1,0 +1,16 @@
+import { TFunction } from 'i18next'
+
+import { PublishCornerFormState } from '../PublishCornerModal.types'
+
+export type LocationStepErrors = Partial<
+  Record<'addressSearch' | 'street' | 'number' | 'photo' | 'consent', string>
+>
+
+export type LocationStepProps = {
+  t: TFunction
+  state: PublishCornerFormState
+  errors: LocationStepErrors
+  onChange: (update: Partial<PublishCornerFormState>) => void
+  onPhotoSelect: (files: FileList | null) => void
+  onRemovePhoto: () => void
+}

--- a/frontend/src/components/publish/PublishCornerModal/components/useLocationSearch.ts
+++ b/frontend/src/components/publish/PublishCornerModal/components/useLocationSearch.ts
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { searchAddressSuggestions } from '@src/api/map/geocoding.service'
+import type { GeocodingSuggestion } from '@src/api/map/geocoding.types'
+
+import type { PublishCornerFormState } from '../PublishCornerModal.types'
+
+type UseLocationSearchParams = {
+  state: PublishCornerFormState
+  t: (key: string) => string
+  onChange: (update: Partial<PublishCornerFormState>) => void
+}
+
+const SEARCH_DEBOUNCE_MS = 250
+
+export const useLocationSearch = ({
+  state,
+  t,
+  onChange,
+}: UseLocationSearchParams) => {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const blurTimeoutRef = useRef<number | null>(null)
+  const requestIdRef = useRef(0)
+
+  const [searchValue, setSearchValue] = useState(state.addressSearch)
+  const [suggestions, setSuggestions] = useState<GeocodingSuggestion[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1)
+
+  const hasSelection = useMemo(
+    () => Boolean(state.latitude.trim() && state.longitude.trim()),
+    [state.latitude, state.longitude]
+  )
+
+  const hasSearchValue = searchValue.trim().length > 0
+
+  const mapCenter = useMemo(() => {
+    if (!hasSelection) return null
+    return [Number(state.latitude), Number(state.longitude)] as [number, number]
+  }, [hasSelection, state.latitude, state.longitude])
+
+  useEffect(() => {
+    if (!hasSelection) return
+    setSuggestions([])
+    setIsSearching(false)
+    setSearchError(null)
+    setShowSuggestions(false)
+    setSearchValue(state.addressSearch)
+  }, [hasSelection, state.addressSearch])
+
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) {
+        window.clearTimeout(blurTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasSelection) return
+
+    if (!hasSearchValue) {
+      setSuggestions([])
+      setIsSearching(false)
+      setSearchError(null)
+      setActiveSuggestionIndex(-1)
+      return
+    }
+
+    const timeout = window.setTimeout(async () => {
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
+      setIsSearching(true)
+
+      try {
+        const results = await searchAddressSuggestions(searchValue)
+        if (requestIdRef.current !== requestId) return
+        setSuggestions(results)
+        setSearchError(null)
+        setActiveSuggestionIndex(results.length > 0 ? 0 : -1)
+      } catch {
+        if (requestIdRef.current !== requestId) return
+        setSuggestions([])
+        setSearchError(t('publishCorner.errors.addressSearchFailed'))
+        setActiveSuggestionIndex(-1)
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setIsSearching(false)
+        }
+      }
+    }, SEARCH_DEBOUNCE_MS)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [hasSearchValue, hasSelection, searchValue, t])
+
+  const handleSearchChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setSearchValue(value)
+      setShowSuggestions(true)
+      setSearchError(null)
+      setActiveSuggestionIndex(-1)
+      onChange({
+        addressSearch: value,
+        latitude: '',
+        longitude: '',
+      })
+    },
+    [onChange]
+  )
+
+  const handleSelectSuggestion = useCallback(
+    (suggestion: GeocodingSuggestion) => {
+      onChange({
+        addressSearch: suggestion.label,
+        street: suggestion.street,
+        number: suggestion.number,
+        postalCode: suggestion.postalCode ?? '',
+        latitude: suggestion.coordinates.latitude.toString(),
+        longitude: suggestion.coordinates.longitude.toString(),
+      })
+      setSearchValue(suggestion.label)
+      setSuggestions([])
+      setShowSuggestions(false)
+      setSearchError(null)
+      setActiveSuggestionIndex(-1)
+    },
+    [onChange]
+  )
+
+  const handleSearchKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!showSuggestions || suggestions.length === 0) return
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActiveSuggestionIndex((prev) =>
+          prev + 1 >= suggestions.length ? 0 : prev + 1
+        )
+        return
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveSuggestionIndex((prev) =>
+          prev - 1 < 0 ? suggestions.length - 1 : prev - 1
+        )
+        return
+      }
+
+      if (event.key === 'Enter') {
+        if (activeSuggestionIndex < 0) return
+        event.preventDefault()
+        handleSelectSuggestion(suggestions[activeSuggestionIndex])
+        return
+      }
+
+      if (event.key === 'Escape') {
+        setShowSuggestions(false)
+      }
+    },
+    [
+      activeSuggestionIndex,
+      handleSelectSuggestion,
+      showSuggestions,
+      suggestions,
+    ]
+  )
+
+  const handleInputFocus = useCallback(() => {
+    if (!hasSelection && suggestions.length > 0) {
+      setShowSuggestions(true)
+    }
+  }, [hasSelection, suggestions.length])
+
+  const handleInputBlur = useCallback(() => {
+    blurTimeoutRef.current = window.setTimeout(() => {
+      setShowSuggestions(false)
+    }, 150)
+  }, [])
+
+  const handleSuggestionMouseDown = useCallback(
+    (
+      event: React.MouseEvent<HTMLButtonElement>,
+      suggestion: GeocodingSuggestion
+    ) => {
+      event.preventDefault()
+      if (blurTimeoutRef.current) {
+        window.clearTimeout(blurTimeoutRef.current)
+        blurTimeoutRef.current = null
+      }
+      handleSelectSuggestion(suggestion)
+    },
+    [handleSelectSuggestion]
+  )
+
+  const handleChangeAddress = useCallback(() => {
+    setSearchValue('')
+    setSuggestions([])
+    setSearchError(null)
+    setShowSuggestions(false)
+    setActiveSuggestionIndex(-1)
+    onChange({
+      addressSearch: '',
+      street: '',
+      number: '',
+      unit: '',
+      postalCode: '',
+      latitude: '',
+      longitude: '',
+    })
+    window.setTimeout(() => {
+      inputRef.current?.focus()
+    }, 50)
+  }, [onChange])
+
+  const hasNoResults =
+    !isSearching &&
+    !searchError &&
+    showSuggestions &&
+    hasSearchValue &&
+    suggestions.length === 0
+
+  const suggestionListId = 'publish-corner-address-suggestions'
+
+  return {
+    inputRef,
+    searchValue,
+    setSearchValue,
+    hasSelection,
+    mapCenter,
+    showSuggestions,
+    suggestions,
+    isSearching,
+    searchError,
+    hasNoResults,
+    suggestionListId,
+    activeSuggestionIndex,
+    handleSearchChange,
+    handleSearchKeyDown,
+    handleInputFocus,
+    handleInputBlur,
+    handleSuggestionMouseDown,
+    handleChangeAddress,
+  }
+}

--- a/frontend/src/components/publish/PublishCornerModal/useCornerForm.ts
+++ b/frontend/src/components/publish/PublishCornerModal/useCornerForm.ts
@@ -1,0 +1,412 @@
+import { PublishCornerPayload } from '@api/community/corners.types'
+import { PublishModalAction } from '@components/publish/shared'
+import { useCreateCorner } from '@hooks/api/useCreateCorner'
+import { useFocusTrap } from '@hooks/useFocusTrap'
+import { usePublishDraft } from '@hooks/usePublishDraft'
+import { stripDraftMeta } from '@utils/drafts'
+import type { TFunction } from 'i18next'
+import isEqual from 'lodash/isEqual'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'react-toastify'
+
+import {
+  STORAGE_KEY,
+  initialState,
+  stepOrder,
+  toSerializableDraft,
+} from './PublishCornerModal.constants'
+import type {
+  PublishCornerDraftState,
+  PublishCornerFormState,
+} from './PublishCornerModal.types'
+
+const sanitizeDraft = (
+  draft: PublishCornerDraftState | null
+): PublishCornerFormState => {
+  if (!draft) return initialState
+  return {
+    ...initialState,
+    ...draft,
+    photo: draft.photo ? { ...draft.photo } : null,
+  }
+}
+
+const useBodyScrollLock = (isOpen: boolean) => {
+  useEffect(() => {
+    if (!isOpen) return
+    const original = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = original
+    }
+  }, [isOpen])
+}
+
+const useCornerDraft = () =>
+  usePublishDraft<PublishCornerDraftState>({ storageKey: STORAGE_KEY })
+
+type UseCornerFormParams = {
+  isOpen: boolean
+  onClose: () => void
+  onCreated: (cornerId: string) => void
+  t: TFunction
+}
+
+export const useCornerForm = ({
+  isOpen,
+  onClose,
+  onCreated,
+  t,
+}: UseCornerFormParams) => {
+  const { draft: storedDraft, saveNow, scheduleSave, clear } = useCornerDraft()
+  const draft = useMemo(() => stripDraftMeta(storedDraft), [storedDraft])
+  const [state, setState] = useState<PublishCornerFormState>(initialState)
+  const [autosaveEnabled, setAutosaveEnabled] = useState(true)
+  const [initialized, setInitialized] = useState(false)
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  const { mutateAsync, isPending } = useCreateCorner()
+
+  const baselineDraft = useMemo(
+    () => draft ?? toSerializableDraft(initialState),
+    [draft]
+  )
+  const serializableState = useMemo(() => toSerializableDraft(state), [state])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInitialized(false)
+      setAutosaveEnabled(true)
+      return
+    }
+    if (initialized) return
+    setInitialized(true)
+    setState(sanitizeDraft(draft))
+  }, [draft, initialized, isOpen])
+
+  useEffect(() => {
+    if (!isOpen || !autosaveEnabled) return
+    if (isEqual(serializableState, baselineDraft)) return
+    scheduleSave(serializableState)
+  }, [autosaveEnabled, baselineDraft, isOpen, scheduleSave, serializableState])
+
+  const updateState = useCallback((update: Partial<PublishCornerFormState>) => {
+    setAutosaveEnabled(true)
+    setState((prev) => ({ ...prev, ...update }))
+  }, [])
+
+  const closeWithConfirmation = useCallback(() => {
+    const hasChanges = !isEqual(serializableState, baselineDraft)
+    if (hasChanges) {
+      const confirmed = window.confirm(t('publishCorner.confirmClose'))
+      if (!confirmed) {
+        return
+      }
+    }
+    onClose()
+  }, [baselineDraft, onClose, serializableState, t])
+
+  useFocusTrap({
+    containerRef: modalRef,
+    active: isOpen,
+    onEscape: closeWithConfirmation,
+  })
+  useBodyScrollLock(isOpen)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isEqual(serializableState, baselineDraft)) {
+        event.preventDefault()
+        event.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [baselineDraft, isOpen, serializableState])
+
+  const handleSaveDraft = useCallback(() => {
+    saveNow(serializableState)
+    toast.success(t('publishCorner.draftSaved'))
+  }, [saveNow, serializableState, t])
+
+  const handlePhotoSelect = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return
+      const file = files[0]
+      const reader = new FileReader()
+      reader.onload = () => {
+        updateState({
+          photo: {
+            id: `${file.name}-${Date.now()}`,
+            url: String(reader.result),
+            alt: file.name,
+          },
+        })
+      }
+      reader.onerror = () => {
+        toast.error(t('publishCorner.errors.photoRead'))
+      }
+      reader.readAsDataURL(file)
+    },
+    [t, updateState]
+  )
+
+  const handleRemovePhoto = useCallback(() => {
+    updateState({ photo: null })
+  }, [updateState])
+
+  const detailsErrors = useMemo(() => {
+    const errors: { [key: string]: string } = {}
+    if (!state.name.trim()) {
+      errors.name = t('publishCorner.errors.name')
+    }
+    if (!state.hostAlias.trim()) {
+      errors.hostAlias = t('publishCorner.errors.hostAlias')
+    }
+    if (!state.internalContact.trim()) {
+      errors.internalContact = t('publishCorner.errors.internalContact')
+    }
+    return errors
+  }, [state.hostAlias, state.internalContact, state.name, t])
+
+  const locationErrors = useMemo(() => {
+    const errors: { [key: string]: string } = {}
+
+    if (!state.street.trim()) {
+      errors.street = t('publishCorner.errors.street')
+    }
+
+    if (!state.number.trim()) {
+      errors.number = t('publishCorner.errors.number')
+    }
+
+    const latitude = Number(state.latitude)
+    const longitude = Number(state.longitude)
+
+    if (!state.addressSearch.trim()) {
+      errors.addressSearch = t('publishCorner.errors.addressSearch')
+    } else if (
+      !state.latitude.trim() ||
+      Number.isNaN(latitude) ||
+      !state.longitude.trim() ||
+      Number.isNaN(longitude)
+    ) {
+      errors.addressSearch = t('publishCorner.errors.addressSearch')
+    } else if (latitude < -90 || latitude > 90) {
+      errors.addressSearch = t('publishCorner.errors.latitudeRange')
+    } else if (longitude < -180 || longitude > 180) {
+      errors.addressSearch = t('publishCorner.errors.longitudeRange')
+    }
+
+    if (!state.photo) {
+      errors.photo = t('publishCorner.errors.photo')
+    }
+
+    if (!state.consent) {
+      errors.consent = t('publishCorner.errors.consent')
+    }
+
+    return errors
+  }, [
+    state.addressSearch,
+    state.consent,
+    state.latitude,
+    state.longitude,
+    state.number,
+    state.photo,
+    state.street,
+    t,
+  ])
+
+  const canProceedDetails = useMemo(
+    () => Object.keys(detailsErrors).length === 0,
+    [detailsErrors]
+  )
+
+  const canProceedLocation = useMemo(
+    () =>
+      Object.keys(locationErrors).filter((key) => key !== 'consent').length ===
+      0,
+    [locationErrors]
+  )
+
+  const publishDisabled = useMemo(
+    () =>
+      isPending ||
+      !state.consent ||
+      !state.photo ||
+      !state.addressSearch.trim() ||
+      !state.street.trim() ||
+      !state.number.trim() ||
+      !state.latitude.trim() ||
+      !state.longitude.trim() ||
+      !canProceedDetails ||
+      !canProceedLocation,
+    [
+      canProceedDetails,
+      canProceedLocation,
+      isPending,
+      state.addressSearch,
+      state.latitude,
+      state.longitude,
+      state.consent,
+      state.photo,
+      state.number,
+      state.street,
+    ]
+  )
+
+  const handleNext = useCallback(() => {
+    setAutosaveEnabled(true)
+    setState((prev) => ({
+      ...prev,
+      step: prev.step === 'details' ? 'location' : 'review',
+    }))
+  }, [])
+
+  const handleBack = useCallback(() => {
+    setAutosaveEnabled(true)
+    setState((prev) => ({
+      ...prev,
+      step: prev.step === 'review' ? 'location' : 'details',
+    }))
+  }, [])
+
+  const handlePublish = useCallback(async () => {
+    if (!state.photo) return
+    const payload: PublishCornerPayload = {
+      name: state.name,
+      scope: state.scope,
+      hostAlias: state.hostAlias,
+      internalContact: state.internalContact,
+      rules: state.rules || undefined,
+      schedule: state.schedule || undefined,
+      location: {
+        address: {
+          street: state.street.trim(),
+          number: state.number.trim(),
+          unit: state.unit.trim() || undefined,
+          postalCode: state.postalCode.trim() || undefined,
+        },
+        coordinates: {
+          latitude: Number(state.latitude),
+          longitude: Number(state.longitude),
+        },
+        visibilityPreference: state.visibilityPreference,
+      },
+      consent: state.consent,
+      photo: {
+        id: state.photo.id,
+        url: state.photo.url,
+      },
+      status: state.status,
+      draft: false,
+    }
+
+    try {
+      const created = await mutateAsync(payload)
+      toast.success(t('publishCorner.published'))
+      clear()
+      setState(initialState)
+      setAutosaveEnabled(true)
+      onCreated(created.id)
+      onClose()
+    } catch {
+      toast.error(t('publishCorner.errors.publish'))
+    }
+  }, [clear, mutateAsync, onClose, onCreated, state, t])
+
+  const stepperSteps = useMemo(
+    () =>
+      stepOrder.map((step) => ({
+        id: step,
+        label: t(`publishCorner.steps.${step}.title`),
+        description: t(`publishCorner.steps.${step}.description`),
+      })),
+    [t]
+  )
+
+  const leftActions = useMemo<PublishModalAction[]>(
+    () => [
+      {
+        label: t('publishCorner.actions.cancel'),
+        onClick: closeWithConfirmation,
+        variant: 'secondary',
+      },
+      {
+        label: t('publishCorner.actions.saveDraft'),
+        onClick: handleSaveDraft,
+        variant: 'secondary',
+      },
+    ],
+    [closeWithConfirmation, handleSaveDraft, t]
+  )
+
+  const rightActions = useMemo<PublishModalAction[]>(() => {
+    const actions: PublishModalAction[] = []
+    if (state.step !== 'details') {
+      actions.push({
+        label: t('publishCorner.actions.back'),
+        onClick: handleBack,
+        variant: 'secondary',
+      })
+    }
+
+    if (state.step === 'details') {
+      actions.push({
+        label: t('publishCorner.actions.next'),
+        onClick: handleNext,
+        variant: 'primary',
+        disabled: !canProceedDetails,
+      })
+    } else if (state.step === 'location') {
+      actions.push({
+        label: t('publishCorner.actions.next'),
+        onClick: handleNext,
+        variant: 'primary',
+        disabled: !canProceedLocation,
+      })
+    } else {
+      actions.push({
+        label: isPending
+          ? t('publishCorner.actions.publishing')
+          : t('publishCorner.actions.publish'),
+        onClick: handlePublish,
+        variant: 'primary',
+        disabled: publishDisabled,
+      })
+    }
+
+    return actions
+  }, [
+    canProceedDetails,
+    canProceedLocation,
+    handleBack,
+    handleNext,
+    handlePublish,
+    isPending,
+    publishDisabled,
+    state.step,
+    t,
+  ])
+
+  return {
+    modalRef,
+    state,
+    updateState,
+    detailsErrors,
+    locationErrors,
+    canProceedDetails,
+    canProceedLocation,
+    publishDisabled,
+    stepperSteps,
+    leftActions,
+    rightActions,
+    handlePhotoSelect,
+    handleRemovePhoto,
+    closeWithConfirmation,
+  }
+}

--- a/frontend/src/pages/map/MapPage.tsx
+++ b/frontend/src/pages/map/MapPage.tsx
@@ -122,12 +122,15 @@ export const MapPage = () => {
     })
   }, [data, layers])
 
-  const isEmpty = Boolean(
-    data &&
-      data.corners.length === 0 &&
-      data.publications.length === 0 &&
-      data.activity.length === 0
-  )
+  const visibleCorners = layers.corners ? (data?.corners?.length ?? 0) : 0
+  const visiblePublications = layers.publications
+    ? (data?.publications?.length ?? 0)
+    : 0
+  const visibleActivity =
+    layers.activity && filters.recentActivity
+      ? (data?.activity?.length ?? 0)
+      : 0
+  const isEmpty = visibleCorners + visiblePublications + visibleActivity === 0
 
   const activityPoints = filters.recentActivity ? (data?.activity ?? []) : []
 

--- a/frontend/tests/components/publish/LocationPhotoUpload.test.tsx
+++ b/frontend/tests/components/publish/LocationPhotoUpload.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { PublishCornerFormState } from '@components/publish/PublishCornerModal/PublishCornerModal.types'
+import { LocationPhotoUpload } from '@components/publish/PublishCornerModal/components/LocationPhotoUpload'
+import type { LocationStepErrors } from '@components/publish/PublishCornerModal/components/LocationStep.types'
+
+type MockFileUploadProps = {
+  previews?: Array<{ id: string; url: string; alt?: string }>
+  hint?: string
+  removeLabel?: string
+  onFilesSelected?: (files: FileList | null) => void
+  onDropFiles?: (files: FileList) => void
+  onRemoveFile?: (id: string) => void
+}
+
+const renderMock = vi.fn<(props: MockFileUploadProps) => void>()
+
+vi.mock('@components/publish/shared', () => ({
+  PublishFileUpload: (props: MockFileUploadProps) => {
+    renderMock(props)
+    return (
+      <div data-testid="mock-file-upload">
+        {(props.previews?.length ?? 0) > 0 ? (
+          <span data-testid="preview-present">preview</span>
+        ) : null}
+        {props.hint ? <span data-testid="hint">{props.hint}</span> : null}
+        <span data-testid="remove-label">{props.removeLabel}</span>
+      </div>
+    )
+  },
+}))
+
+type Props = {
+  state?: Partial<PublishCornerFormState>
+  errors?: LocationStepErrors
+  onPhotoSelect?: (files: FileList | null) => void
+  onRemovePhoto?: () => void
+  t?: (key: string) => string
+}
+
+const baseState: PublishCornerFormState = {
+  step: 'location',
+  name: '',
+  scope: 'public',
+  hostAlias: '',
+  internalContact: '',
+  rules: '',
+  schedule: '',
+  street: '',
+  number: '',
+  unit: '',
+  postalCode: '',
+  addressSearch: '',
+  latitude: '',
+  longitude: '',
+  visibilityPreference: 'exact',
+  photo: null,
+  consent: false,
+  status: 'active',
+}
+
+const setup = ({
+  state,
+  errors,
+  onPhotoSelect = vi.fn(),
+  onRemovePhoto = vi.fn(),
+  t = (key: string) => key,
+}: Props = {}) => {
+  renderMock.mockReset()
+
+  const mergedState = { ...baseState, ...state }
+  const mergedErrors: LocationStepErrors = { ...errors }
+
+  render(
+    <LocationPhotoUpload
+      t={t}
+      state={mergedState}
+      errors={mergedErrors}
+      onPhotoSelect={onPhotoSelect}
+      onRemovePhoto={onRemovePhoto}
+    />
+  )
+
+  const lastCall = renderMock.mock.calls.at(-1)
+  const props = lastCall ? lastCall[0] : {}
+
+  return { onPhotoSelect, onRemovePhoto, mergedState, props }
+}
+
+describe('LocationPhotoUpload', () => {
+  test('renders uploader without preview and handles selection flows', () => {
+    const selectFiles = { length: 1 } as unknown as FileList
+    const dropFiles = { length: 2 } as unknown as FileList
+
+    const onPhotoSelect = vi.fn()
+    const { props } = setup({ onPhotoSelect })
+    expect(props.previews).toHaveLength(0)
+
+    props.onFilesSelected?.(selectFiles)
+    props.onDropFiles?.(dropFiles)
+
+    expect(onPhotoSelect).toHaveBeenNthCalledWith(1, selectFiles)
+    expect(onPhotoSelect).toHaveBeenNthCalledWith(2, dropFiles)
+    expect(screen.getByTestId('hint')).toHaveTextContent(
+      'publishCorner.fields.photoHint'
+    )
+    expect(screen.getByTestId('remove-label')).toHaveTextContent(
+      'publishCorner.fields.photoRemove'
+    )
+  })
+
+  test('shows preview, handles removal and falls back on optional translations', () => {
+    const onRemovePhoto = vi.fn()
+    const photo = { id: '1', url: 'photo.jpg', alt: 'alt' }
+    const t = (key: string) => {
+      if (
+        key === 'publishCorner.fields.photoHint' ||
+        key === 'publishCorner.fields.photoRemove'
+      ) {
+        return undefined as unknown as string
+      }
+      return key
+    }
+
+    const setupResult = setup({
+      state: { photo },
+      onRemovePhoto,
+      t,
+    })
+    const { props } = setupResult
+    expect(props.previews).toEqual([photo])
+
+    expect(screen.getByTestId('preview-present')).toBeInTheDocument()
+    props.onRemoveFile?.(photo.id)
+    expect(onRemovePhoto).toHaveBeenCalled()
+    expect(screen.queryByTestId('hint')).not.toBeInTheDocument()
+    expect(screen.getByTestId('remove-label')).toHaveTextContent('')
+  })
+})

--- a/frontend/tests/components/publish/LocationSearchSection.test.tsx
+++ b/frontend/tests/components/publish/LocationSearchSection.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { LocationSearchSection } from '@components/publish/PublishCornerModal/components/LocationSearchSection'
+import type { GeocodingSuggestion } from '@src/api/map/geocoding.types'
+
+const { MapContainerMock, TileLayerMock, CircleMarkerMock } = vi.hoisted(
+  () => ({
+    MapContainerMock: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="map-container">{children}</div>
+    ),
+    TileLayerMock: () => <div data-testid="tile-layer" />,
+    CircleMarkerMock: () => <div data-testid="circle-marker" />,
+  })
+)
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: MapContainerMock,
+  TileLayer: TileLayerMock,
+  CircleMarker: CircleMarkerMock,
+}))
+
+const t = (key: string) => key
+
+type LocationSearchSectionProps = React.ComponentProps<
+  typeof LocationSearchSection
+>
+
+type SetupOptions = Partial<LocationSearchSectionProps>
+
+const suggestions: GeocodingSuggestion[] = [
+  {
+    id: '1',
+    label: 'Libertad 100',
+    street: 'Libertad',
+    number: '100',
+    secondaryLabel: 'Recoleta',
+    coordinates: { latitude: -34.6, longitude: -58.4 },
+  },
+  {
+    id: '2',
+    label: 'Libertad 200',
+    street: 'Libertad',
+    number: '200',
+    coordinates: { latitude: -34.61, longitude: -58.41 },
+  },
+]
+
+const setup = (options: SetupOptions = {}) => {
+  const onSuggestionMouseDown =
+    vi.fn<LocationSearchSectionProps['onSuggestionMouseDown']>()
+  const onChangeAddress = vi.fn<LocationSearchSectionProps['onChangeAddress']>()
+
+  const props: LocationSearchSectionProps = {
+    t,
+    errors: {},
+    searchValue: '',
+    inputRef: React.createRef<HTMLInputElement>(),
+    onSearchChange: vi.fn(),
+    onFocus: vi.fn(),
+    onBlur: vi.fn(),
+    onKeyDown: vi.fn(),
+    disabled: false,
+    showSuggestions: false,
+    suggestions: [],
+    suggestionListId: 'test-suggestions',
+    activeSuggestionIndex: -1,
+    onSuggestionMouseDown,
+    hasSelection: false,
+    hasNoResults: false,
+    isSearching: false,
+    searchError: null,
+    onChangeAddress,
+    mapCenter: null,
+    ...options,
+  }
+
+  const utils = render(<LocationSearchSection {...props} />)
+
+  return {
+    ...utils,
+    props,
+    onSuggestionMouseDown,
+    onChangeAddress,
+  }
+}
+
+describe('LocationSearchSection', () => {
+  test('renders suggestions list and handles selection callbacks', () => {
+    const { onSuggestionMouseDown } = setup({
+      searchValue: 'Liber',
+      showSuggestions: true,
+      suggestions,
+      activeSuggestionIndex: 0,
+    })
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(2)
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.mouseDown(options[1])
+    expect(onSuggestionMouseDown).toHaveBeenCalled()
+    const [event, suggestion] = onSuggestionMouseDown.mock.calls[0]
+    expect(event?.type).toBe('mousedown')
+    expect(suggestion).toEqual(suggestions[1])
+  })
+
+  test('shows search statuses and error messages', () => {
+    const { rerender, props } = setup({
+      searchValue: 'Libertad',
+      showSuggestions: true,
+      suggestions: [],
+      isSearching: true,
+    })
+
+    expect(
+      screen.getByText('publishCorner.location.searching')
+    ).toBeInTheDocument()
+
+    rerender(
+      <LocationSearchSection
+        {...props}
+        isSearching={false}
+        searchError="Network error"
+      />
+    )
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+
+    rerender(
+      <LocationSearchSection
+        {...props}
+        isSearching={false}
+        showSuggestions
+        suggestions={[]}
+        hasNoResults
+        searchError={null}
+      />
+    )
+    expect(
+      screen.getByText('publishCorner.errors.addressNoResults')
+    ).toBeInTheDocument()
+  })
+
+  test('renders map preview when a selection exists', () => {
+    const { rerender, props, onChangeAddress } = setup({
+      hasSelection: true,
+      mapCenter: null,
+    })
+
+    const changeButton = screen.getByRole('button', {
+      name: 'publishCorner.actions.changeAddress',
+    })
+    fireEvent.click(changeButton)
+    expect(onChangeAddress).toHaveBeenCalled()
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument()
+
+    rerender(
+      <LocationSearchSection
+        {...props}
+        hasSelection
+        mapCenter={[-34.6, -58.4]}
+        onChangeAddress={onChangeAddress}
+      />
+    )
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument()
+    expect(screen.getByTestId('circle-marker')).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/components/publish/LocationStep.test.tsx
+++ b/frontend/tests/components/publish/LocationStep.test.tsx
@@ -1,0 +1,251 @@
+import { act, render } from '@testing-library/react'
+import React, { useImperativeHandle, useState } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { useLocationSearch } from '@components/publish/PublishCornerModal/components/useLocationSearch'
+import { initialState } from '@components/publish/PublishCornerModal/PublishCornerModal.constants'
+import type { PublishCornerFormState } from '@components/publish/PublishCornerModal/PublishCornerModal.types'
+
+vi.mock('leaflet/dist/leaflet.css', () => ({}))
+
+const { searchMock } = vi.hoisted(() => ({
+  searchMock: vi.fn<
+    (term: string) => Promise<
+      Array<{
+        id: string
+        label: string
+        street: string
+        number: string
+        postalCode?: string
+        secondaryLabel?: string
+        coordinates: { latitude: number; longitude: number }
+      }>
+    >
+  >(),
+}))
+
+vi.mock('@src/api/map/geocoding.service', () => ({
+  searchAddressSuggestions: searchMock,
+}))
+
+type ImperativeApi = ReturnType<typeof useLocationSearch> & {
+  state: PublishCornerFormState
+}
+
+const t = (key: string) => key
+
+type TestComponentProps = {
+  initial?: Partial<PublishCornerFormState>
+}
+
+const TestComponent = React.forwardRef<ImperativeApi, TestComponentProps>(
+  ({ initial }, ref) => {
+    const [state, setState] = useState<PublishCornerFormState>({
+      ...initialState,
+      ...initial,
+    })
+
+    const search = useLocationSearch({
+      state,
+      t,
+      onChange: (update) => setState((prev) => ({ ...prev, ...update })),
+    })
+
+    useImperativeHandle(ref, () => ({ ...search, state }))
+    return null
+  }
+)
+
+describe('useLocationSearch', () => {
+  test('handles suggestion flow and selection', async () => {
+    vi.useFakeTimers()
+    searchMock.mockResolvedValue([
+      {
+        id: '1',
+        label: 'Libertad 100',
+        street: 'Libertad',
+        number: '100',
+        coordinates: { latitude: -34.6, longitude: -58.4 },
+      },
+      {
+        id: '2',
+        label: 'Libertad 200',
+        street: 'Libertad',
+        number: '200',
+        coordinates: { latitude: -34.61, longitude: -58.41 },
+      },
+    ])
+
+    const ref = React.createRef<ImperativeApi>()
+    render(<TestComponent ref={ref} />)
+
+    const changeEvent = {
+      target: { value: 'Libertad' },
+    } as React.ChangeEvent<HTMLInputElement>
+
+    act(() => {
+      ref.current?.handleSearchChange(changeEvent)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    expect(ref.current?.suggestions).toHaveLength(2)
+
+    act(() => {
+      ref.current?.handleSearchKeyDown({
+        key: 'ArrowDown',
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      ref.current?.handleSearchKeyDown({
+        key: 'Enter',
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>)
+    })
+
+    expect(ref.current?.state.street).toBe('Libertad')
+    expect(ref.current?.state.latitude).toBe('-34.6')
+    expect(ref.current?.suggestions).toHaveLength(0)
+
+    vi.useRealTimers()
+  })
+
+  test('exposes errors when the search request fails', async () => {
+    vi.useFakeTimers()
+    searchMock.mockRejectedValue(new Error('network'))
+
+    const ref = React.createRef<ImperativeApi>()
+    render(<TestComponent ref={ref} />)
+
+    act(() => {
+      ref.current?.handleSearchChange({
+        target: { value: 'Sinclair' },
+      } as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    expect(ref.current?.searchError).toBe(
+      'publishCorner.errors.addressSearchFailed'
+    )
+    expect(ref.current?.suggestions).toHaveLength(0)
+
+    vi.useRealTimers()
+  })
+
+  test('resets selection through handleChangeAddress', async () => {
+    const ref = React.createRef<ImperativeApi>()
+    render(
+      <TestComponent
+        ref={ref}
+        initial={{
+          addressSearch: 'Libertad 100',
+          street: 'Libertad',
+          number: '100',
+          latitude: '-34.6',
+          longitude: '-58.4',
+        }}
+      />
+    )
+
+    act(() => {
+      ref.current?.handleChangeAddress()
+    })
+
+    expect(ref.current?.state.addressSearch).toBe('')
+    expect(ref.current?.state.street).toBe('')
+    expect(ref.current?.state.latitude).toBe('')
+    expect(ref.current?.hasSelection).toBe(false)
+  })
+
+  test('handles focus, keyboard navigation and suggestion mouse interactions', async () => {
+    vi.useFakeTimers()
+    searchMock.mockResolvedValue([
+      {
+        id: '1',
+        label: 'Libertad 100',
+        street: 'Libertad',
+        number: '100',
+        coordinates: { latitude: -34.6, longitude: -58.4 },
+      },
+      {
+        id: '2',
+        label: 'Libertad 200',
+        street: 'Libertad',
+        number: '200',
+        coordinates: { latitude: -34.61, longitude: -58.41 },
+      },
+    ])
+
+    const ref = React.createRef<ImperativeApi>()
+    render(<TestComponent ref={ref} />)
+
+    act(() => {
+      ref.current?.handleSearchChange({
+        target: { value: 'Lib' },
+      } as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    expect(ref.current?.suggestions).toHaveLength(2)
+    expect(ref.current?.showSuggestions).toBe(true)
+    expect(ref.current?.activeSuggestionIndex).toBe(0)
+
+    act(() => {
+      ref.current?.handleSearchKeyDown({
+        key: 'ArrowUp',
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>)
+    })
+
+    expect(ref.current?.activeSuggestionIndex).toBe(1)
+
+    act(() => {
+      ref.current?.handleSearchKeyDown({
+        key: 'Escape',
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>)
+    })
+
+    expect(ref.current?.showSuggestions).toBe(false)
+
+    act(() => {
+      ref.current?.handleInputFocus()
+      ref.current?.handleInputBlur()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+
+    expect(ref.current?.showSuggestions).toBe(false)
+
+    const preventDefault = vi.fn()
+
+    act(() => {
+      ref.current?.handleInputFocus()
+      ref.current?.handleSuggestionMouseDown(
+        { preventDefault } as unknown as React.MouseEvent<HTMLButtonElement>,
+        {
+          id: '2',
+          label: 'Libertad 200',
+          street: 'Libertad',
+          number: '200',
+          coordinates: { latitude: -34.61, longitude: -58.41 },
+        }
+      )
+    })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(ref.current?.state.addressSearch).toBe('Libertad 200')
+    expect(ref.current?.state.latitude).toBe('-34.61')
+
+    vi.useRealTimers()
+  })
+})

--- a/frontend/tests/pages/map/MapPage.test.tsx
+++ b/frontend/tests/pages/map/MapPage.test.tsx
@@ -236,4 +236,29 @@ describe('MapPage', () => {
       trackSpy.mockRestore()
     }
   })
+
+  test('only shows the empty state when all visible datasets are empty', async () => {
+    renderWithProviders(<MapPage />)
+
+    await waitFor(() => {
+      expect(getPinButtons().length).toBeGreaterThan(0)
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'map.filters.types.corners' })
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'map.filters.types.publications' })
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'map.filters.activity' })
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'map.filters.recentActivity' })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('map.empty.title')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- refactor the publish corner location step into focused subcomponents and the `useCornerForm` hook for autosave, validation, and modal orchestration
- add dedicated unit tests for the location search workflow, photo upload control, and publish modal location logic to raise branch coverage above 85%
- harden the map page empty-state handling and expand its test coverage to verify the new logic

## Testing
- npm run test:frontend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e2cd14161c832e8a7e234a52c0d0fc