### PR TITLE
Add message composer with attachment modals

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -173,6 +173,7 @@ Feature 5.1 Mensajería 1:1
   - Actualización 2025-09-29: se ajustaron los mocks del chat al español y se corrigió el layout para que la barra de mensajes permanezca visible mientras el historial hace scroll.
   - Actualización 2025-09-30: se enriqueció la conversación mockeada con un flujo lógico de intercambio, se diferenciaron visualmente los libros propios vs. del interlocutor y se alinearon las insignias/acciones con la UI.
   - Actualización 2025-10-07: se añadieron pruebas unitarias de burbujas, pestañas y socket mockeado para garantizar traducciones, estados offline/online y envío de mensajes sin regresiones.
+  - Actualización 2025-11-19: se reemplazó la barra de entrada por un compositor accesible con selector de emojis y formularios para adjuntar libros, proponer intercambios y acordar encuentros; se actualizaron los tipos de mensajes, traducciones y pruebas RTL para cubrir los nuevos flujos.
 - [ ] S-5.2 Bloqueo/Reporte en conversación y ficha (Must, E1; BR-43)
   - Éxito: acción en ≤2 pasos.
 

--- a/frontend/mocks/constants/constants.ts
+++ b/frontend/mocks/constants/constants.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_EMAIL = 'u@u'
+export const DEFAULT_EMAIL = 'u@u.com'
 
 export const DEFAULT_PASS = ''

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.5'
-const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const PACKAGE_VERSION = '2.11.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -71,11 +71,6 @@ addEventListener('message', async function (event) {
       break
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
-    }
-
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
@@ -94,6 +89,8 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
     return
@@ -110,23 +107,29 @@ addEventListener('fetch', function (event) {
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
-  // after it's been deleted (still remains active until the next reload).
+  // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
     return
   }
 
   const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
 })
 
 /**
  * @param {FetchEvent} event
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  */
-async function handleRequest(event, requestId) {
+async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -202,9 +205,10 @@ async function resolveMainClient(event) {
  * @param {FetchEvent} event
  * @param {Client | undefined} client
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  * @returns {Promise<Response>}
  */
-async function getResponse(event, client, requestId) {
+async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
   const requestClone = event.request.clone()
@@ -255,6 +259,7 @@ async function getResponse(event, client, requestId) {
       type: 'REQUEST',
       payload: {
         id: requestId,
+        interceptedAt: requestInterceptedAt,
         ...serializedRequest,
       },
     },

--- a/frontend/src/assets/i18n/locales/en/common.json
+++ b/frontend/src/assets/i18n/locales/en/common.json
@@ -406,6 +406,23 @@
     "messages": {
       "title": "Messages",
       "placeholder": "Messages list",
+      "status": {
+        "disconnected": "Disconnected",
+        "disconnectedError": "Disconnected: {{error}}",
+        "online": "Online",
+        "lastSeen": "Last seen {{lastSeen}}",
+        "lastSeenFallback": "just now"
+      },
+      "searchPlaceholder": "Search",
+      "searchAriaLabel": "Search conversations",
+      "actions": {
+        "profile": "View profile info"
+      },
+      "badges": {
+        "unread": "Unread",
+        "book": "Book",
+        "swap": "Swap offer"
+      },
       "agreement": {
         "proposal": {
           "title": "Agreement proposal",
@@ -424,6 +441,66 @@
         "actions": {
           "confirm": "Confirm",
           "suggestChange": "Suggest change"
+        }
+      },
+      "swap": {
+        "proposal": {
+          "title": "Swap proposal",
+          "ariaLabel": "Swap proposal: you offer {{offered}} for {{requested}}",
+          "offered": "You offer",
+          "requested": "You request"
+        }
+      },
+      "composer": {
+        "textLabel": "Write your message",
+        "placeholder": "Write a message...",
+        "send": "Send message",
+        "cancel": "Cancel",
+        "close": "Close",
+        "emoji": {
+          "open": "Emoji",
+          "close": "Close picker",
+          "insert": "Insert emoji {{emoji}}"
+        },
+        "bookModal": {
+          "trigger": "Attach book",
+          "title": "Attach book",
+          "description": "Share a book card within the conversation.",
+          "bookLabel": "Choose a book",
+          "helper": "You can add an optional note for extra context.",
+          "noteLabel": "Note (optional)",
+          "submit": "Attach",
+          "empty": "No books available",
+          "mine": "My books",
+          "theirs": "{{name}}'s books"
+        },
+        "swapModal": {
+          "trigger": "Propose swap",
+          "title": "Swap proposal",
+          "description": "Choose which book you offer and which one you'd like in return.",
+          "offeredLabel": "You offer",
+          "requestedLabel": "You request",
+          "noteLabel": "Additional message (optional)",
+          "helper": "Proposals stay in the conversation so both can review them.",
+          "submit": "Send proposal",
+          "noMine": "You have no books available for swapping.",
+          "noTheirs": "The other person has no books published."
+        },
+        "agreementModal": {
+          "trigger": "Agreement proposal",
+          "title": "Agreement proposal",
+          "description": "Set a meeting point and time to finalize the swap.",
+          "meetingLabel": "Meeting point",
+          "meetingPlaceholder": "e.g. Café at the square",
+          "areaLabel": "Area or neighborhood",
+          "areaPlaceholder": "e.g. Downtown",
+          "dateLabel": "Suggested day",
+          "datePlaceholder": "e.g. Tue 03/12",
+          "timeLabel": "Time",
+          "timePlaceholder": "e.g. 19:00",
+          "bookLabel": "Book to exchange",
+          "noBooks": "No books are listed in this conversation.",
+          "submit": "Send proposal"
         }
       },
       "snippets": {

--- a/frontend/src/assets/i18n/locales/es/common.json
+++ b/frontend/src/assets/i18n/locales/es/common.json
@@ -406,6 +406,23 @@
     "messages": {
       "title": "Mensajes",
       "placeholder": "Lista de mensajes",
+      "status": {
+        "disconnected": "Desconectado",
+        "disconnectedError": "Desconectado: {{error}}",
+        "online": "En línea",
+        "lastSeen": "Última vez {{lastSeen}}",
+        "lastSeenFallback": "hace un momento"
+      },
+      "searchPlaceholder": "Buscar",
+      "searchAriaLabel": "Buscar conversaciones",
+      "actions": {
+        "profile": "Ver información del perfil"
+      },
+      "badges": {
+        "unread": "Sin leer",
+        "book": "Libro",
+        "swap": "Oferta de intercambio"
+      },
       "agreement": {
         "proposal": {
           "title": "Propuesta de acuerdo",
@@ -424,6 +441,66 @@
         "actions": {
           "confirm": "Confirmar",
           "suggestChange": "Proponer cambio"
+        }
+      },
+      "swap": {
+        "proposal": {
+          "title": "Propuesta de intercambio",
+          "ariaLabel": "Propuesta de intercambio: ofrecés {{offered}} por {{requested}}",
+          "offered": "Ofrecés",
+          "requested": "Querés recibir"
+        }
+      },
+      "composer": {
+        "textLabel": "Escribí tu mensaje",
+        "placeholder": "Escribí un mensaje...",
+        "send": "Enviar mensaje",
+        "cancel": "Cancelar",
+        "close": "Cerrar",
+        "emoji": {
+          "open": "Emoji",
+          "close": "Cerrar selector",
+          "insert": "Insertar emoji {{emoji}}"
+        },
+        "bookModal": {
+          "trigger": "Adjuntar libro",
+          "title": "Adjuntar libro",
+          "description": "Compartí una ficha de libro dentro de la conversación.",
+          "bookLabel": "Elegí un libro",
+          "helper": "Podés añadir una nota opcional para darle contexto.",
+          "noteLabel": "Nota (opcional)",
+          "submit": "Adjuntar",
+          "empty": "No hay libros disponibles",
+          "mine": "Mis libros",
+          "theirs": "Libros de {{name}}"
+        },
+        "swapModal": {
+          "trigger": "Proponer intercambio",
+          "title": "Propuesta de intercambio",
+          "description": "Elegí qué libro ofrecés y cuál te gustaría recibir a cambio.",
+          "offeredLabel": "Ofrecés",
+          "requestedLabel": "Querés recibir",
+          "noteLabel": "Mensaje adicional (opcional)",
+          "helper": "Las propuestas se guardan en la conversación para que ambos las revisen.",
+          "submit": "Enviar propuesta",
+          "noMine": "No tenés libros disponibles para intercambio.",
+          "noTheirs": "La otra persona no tiene libros publicados."
+        },
+        "agreementModal": {
+          "trigger": "Propuesta de acuerdo",
+          "title": "Propuesta de acuerdo",
+          "description": "Definí un punto de encuentro y horario para cerrar el intercambio.",
+          "meetingLabel": "Punto de encuentro",
+          "meetingPlaceholder": "Ej. Café de la plaza",
+          "areaLabel": "Zona o barrio",
+          "areaPlaceholder": "Ej. Nervión (Sevilla)",
+          "dateLabel": "Día sugerido",
+          "datePlaceholder": "Ej. Martes 12/03",
+          "timeLabel": "Horario",
+          "timePlaceholder": "Ej. 19:00",
+          "bookLabel": "Libro a intercambiar",
+          "noBooks": "No hay libros cargados en la conversación.",
+          "submit": "Enviar propuesta"
         }
       },
       "snippets": {

--- a/frontend/src/components/messages/MessageComposer.module.scss
+++ b/frontend/src/components/messages/MessageComposer.module.scss
@@ -1,0 +1,181 @@
+@import '@styles/variables';
+
+.composer {
+  display: flex;
+  align-items: flex-end;
+  gap: $spacing-1;
+  width: 100%;
+}
+
+.editor {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.textarea {
+  width: 100%;
+  min-height: rem(56px);
+  max-height: rem(180px);
+  padding: $spacing-2;
+  border: 1px solid var(--border-color);
+  border-radius: rem(16px);
+  background: var(--background-primary);
+  color: var(--text-primary);
+  font: inherit;
+  line-height: 1.4;
+  resize: vertical;
+
+  &:focus {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background: color-mix(in srgb, var(--background-card) 88%, #000 12%);
+  }
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: $spacing-1;
+}
+
+.toolbarGroup {
+  display: flex;
+  gap: $spacing-1;
+  flex-wrap: wrap;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1 / 2;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: $small-font-size;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    background: color-mix(in srgb, var(--background-card) 88%, #000 12%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: var(--text-disabled);
+    background: color-mix(in srgb, var(--background-card) 92%, #000 8%);
+  }
+}
+
+.sendButton {
+  background: rgb(var(--primary-color-rgb));
+  color: #fff;
+  border: none;
+  border-radius: rem(10px);
+  padding: 10px 16px;
+  font-weight: 600;
+  transition: transform 0.04s ease, background 0.15s ease;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: rem(44px);
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &:hover {
+    background: var(--primary-dark);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background: color-mix(in srgb, var(--primary-color) 45%, #000 55%);
+  }
+}
+
+.emojiPopover {
+  position: absolute;
+  bottom: calc(100% + $spacing-1);
+  right: 0;
+  background: var(--background-card);
+  border: 1px solid var(--border-color);
+  border-radius: rem(12px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  z-index: 20;
+  overflow: hidden;
+  max-width: min(320px, 90vw);
+}
+
+.emojiClose {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px;
+}
+
+.closeEmojiButton {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.875rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.emojiList {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(rem(36px), 1fr));
+  gap: 4px;
+  padding: $spacing-1;
+}
+
+.emojiButton {
+  font-size: 1.5rem;
+  line-height: 1;
+  border: none;
+  background: none;
+  border-radius: rem(8px);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+
+  &:hover,
+  &:focus-visible {
+    background: color-mix(in srgb, var(--background-card) 85%, #000 15%);
+  }
+}
+
+.hiddenLabel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.characterCount {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}

--- a/frontend/src/components/messages/MessageComposer.module.scss
+++ b/frontend/src/components/messages/MessageComposer.module.scss
@@ -15,10 +15,10 @@
 }
 
 .textarea {
-  width: 100%;
-  min-height: rem(56px);
-  max-height: rem(180px);
-  padding: $spacing-2;
+  width: 92%;
+  //min-height: rem(56px);
+  //max-height: rem(180px);
+  padding: $spacing-1;
   border: 1px solid var(--border-color);
   border-radius: rem(16px);
   background: var(--background-primary);
@@ -42,6 +42,7 @@
   justify-content: space-between;
   align-items: center;
   margin-top: $spacing-1;
+  width: 95%;
 }
 
 .toolbarGroup {
@@ -53,7 +54,7 @@
 .actionButton {
   display: inline-flex;
   align-items: center;
-  gap: $spacing-1 / 2;
+  gap: calc($spacing-1 / 2);
   padding: 6px 12px;
   border-radius: 999px;
   border: 1px solid transparent;
@@ -61,7 +62,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   font-size: $small-font-size;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 
   &:hover {
     background: color-mix(in srgb, var(--background-card) 88%, #000 12%);
@@ -86,7 +89,9 @@
   border-radius: rem(10px);
   padding: 10px 16px;
   font-weight: 600;
-  transition: transform 0.04s ease, background 0.15s ease;
+  transition:
+    transform 0.04s ease,
+    background 0.15s ease;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -110,11 +115,11 @@
 .emojiPopover {
   position: absolute;
   bottom: calc(100% + $spacing-1);
-  right: 0;
+  right: rem(40px);
   background: var(--background-card);
   border: 1px solid var(--border-color);
   border-radius: rem(12px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
   z-index: 20;
   overflow: hidden;
   max-width: min(320px, 90vw);
@@ -170,7 +175,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(0 0 0 0);
   white-space: nowrap;
   border: 0;
 }

--- a/frontend/src/components/messages/MessageComposer.module.scss
+++ b/frontend/src/components/messages/MessageComposer.module.scss
@@ -16,8 +16,6 @@
 
 .textarea {
   width: 92%;
-  //min-height: rem(56px);
-  //max-height: rem(180px);
   padding: $spacing-1;
   border: 1px solid var(--border-color);
   border-radius: rem(16px);

--- a/frontend/src/components/messages/MessageComposer.tsx
+++ b/frontend/src/components/messages/MessageComposer.tsx
@@ -1,0 +1,349 @@
+import {
+  FormEvent,
+  KeyboardEvent,
+  RefObject,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { cx } from '@utils/cx'
+
+import {
+  AgreementDetails,
+  Book,
+  SwapProposalDetails,
+} from './Messages.types'
+import { AgreementProposalModal } from './composer/AgreementProposalModal'
+import { AttachBookModal } from './composer/AttachBookModal'
+import { SwapProposalModal } from './composer/SwapProposalModal'
+import styles from './MessageComposer.module.scss'
+
+type ActiveModal = 'book' | 'swap' | 'agreement' | null
+
+type MessageComposerProps = {
+  className?: string
+  disabled?: boolean
+  onSendText: (text: string) => void
+  onAttachBook: (bookId: string, note?: string) => void
+  onProposeSwap: (details: SwapProposalDetails) => void
+  onProposeAgreement: (proposal: AgreementDetails) => void
+  myBooks: Book[]
+  theirBooks: Book[]
+  counterpartName: string
+}
+
+const EMOJIS = ['😀', '😁', '😂', '😍', '🤔', '👍', '🎉', '📚']
+
+export const MessageComposer = ({
+  className,
+  disabled,
+  onSendText,
+  onAttachBook,
+  onProposeSwap,
+  onProposeAgreement,
+  myBooks,
+  theirBooks,
+  counterpartName,
+}: MessageComposerProps) => {
+  const { t } = useTranslation()
+  const textareaId = useId()
+  const [draft, setDraft] = useState('')
+  const [isEmojiOpen, setEmojiOpen] = useState(false)
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const emojiTriggerRef = useRef<HTMLButtonElement>(null)
+  const emojiPopoverRef = useRef<HTMLDivElement>(null)
+  const bookButtonRef = useRef<HTMLButtonElement>(null)
+  const swapButtonRef = useRef<HTMLButtonElement>(null)
+  const agreementButtonRef = useRef<HTMLButtonElement>(null)
+  const modalTriggerRef = useRef<HTMLButtonElement | null>(null)
+
+  const closeEmojiPicker = () => {
+    setEmojiOpen(false)
+  }
+
+  const sendDraft = () => {
+    if (disabled) return
+    const cleanDraft = draft.trim()
+    if (!cleanDraft) return
+
+    onSendText(cleanDraft)
+    setDraft('')
+    closeEmojiPicker()
+    textareaRef.current?.focus()
+  }
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    sendDraft()
+  }
+
+  const handleToggleEmoji = () => {
+    if (disabled) return
+    setEmojiOpen((prev) => {
+      const next = !prev
+      if (next) {
+        requestAnimationFrame(() => {
+          textareaRef.current?.focus()
+        })
+      }
+      return next
+    })
+  }
+
+  const handleEmojiSelect = (emoji: string) => {
+    if (disabled || !emoji) return
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const selectionStart = textarea.selectionStart ?? draft.length
+    const selectionEnd = textarea.selectionEnd ?? draft.length
+    const nextValue =
+      draft.slice(0, selectionStart) + emoji + draft.slice(selectionEnd)
+    setDraft(nextValue)
+
+    const cursorPosition = selectionStart + emoji.length
+    requestAnimationFrame(() => {
+      textarea.focus()
+      textarea.setSelectionRange(cursorPosition, cursorPosition)
+    })
+  }
+
+  const handleOpenModal = (
+    type: Exclude<ActiveModal, null>,
+    triggerRef: RefObject<HTMLButtonElement>
+  ) => {
+    if (disabled) return
+    modalTriggerRef.current = triggerRef.current
+    closeEmojiPicker()
+    setActiveModal(type)
+  }
+
+  const handleCloseModal = () => {
+    setActiveModal(null)
+    const trigger = modalTriggerRef.current
+    if (trigger) {
+      requestAnimationFrame(() => {
+        trigger.focus()
+      })
+    }
+  }
+
+  const handleAttachBookConfirm = (bookId: string, note?: string) => {
+    onAttachBook(bookId, note)
+  }
+
+  const handleSwapConfirm = (details: SwapProposalDetails) => {
+    onProposeSwap(details)
+  }
+
+  const handleAgreementConfirm = (proposal: AgreementDetails) => {
+    onProposeAgreement(proposal)
+  }
+
+  const handleTextareaKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key === 'Enter' &&
+      !event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
+      event.preventDefault()
+      sendDraft()
+    }
+  }
+
+  useEffect(() => {
+    if (!isEmojiOpen) return
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!emojiPopoverRef.current) return
+      const target = event.target as Node | null
+      if (
+        target &&
+        !emojiPopoverRef.current.contains(target) &&
+        !emojiTriggerRef.current?.contains(target)
+      ) {
+        closeEmojiPicker()
+      }
+    }
+
+    window.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isEmojiOpen])
+
+  useEffect(() => {
+    if (!disabled) return
+    closeEmojiPicker()
+    setActiveModal(null)
+  }, [disabled])
+
+  useEffect(() => {
+    closeEmojiPicker()
+    setActiveModal(null)
+  }, [myBooks, theirBooks, counterpartName])
+
+  const hasDraft = draft.trim().length > 0
+
+  return (
+    <>
+      <form
+        className={cx(className, styles.composer)}
+        onSubmit={handleFormSubmit}
+        aria-disabled={disabled}
+      >
+        <div className={styles.editor}>
+          <label className={styles.hiddenLabel} htmlFor={textareaId}>
+            {t('community.messages.composer.textLabel', {
+              defaultValue: 'Escribí tu mensaje',
+            })}
+          </label>
+          <textarea
+            id={textareaId}
+            ref={textareaRef}
+            className={styles.textarea}
+            placeholder={t('community.messages.composer.placeholder', {
+              defaultValue: 'Escribí un mensaje...',
+            })}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={handleTextareaKeyDown}
+            disabled={disabled}
+            aria-disabled={disabled}
+          />
+          {isEmojiOpen ? (
+            <div
+              ref={emojiPopoverRef}
+              className={styles.emojiPopover}
+              id={`${textareaId}-emoji-popover`}
+            >
+              <div className={styles.emojiClose}>
+                <button
+                  type="button"
+                  className={styles.closeEmojiButton}
+                  onClick={closeEmojiPicker}
+                >
+                  {t('community.messages.composer.emoji.close', {
+                    defaultValue: 'Cerrar selector',
+                  })}
+                </button>
+              </div>
+              <div className={styles.emojiList}>
+                {EMOJIS.map((emoji) => (
+                  <button
+                    key={emoji}
+                    type="button"
+                    className={styles.emojiButton}
+                    onClick={() => handleEmojiSelect(emoji)}
+                    aria-label={t(
+                      'community.messages.composer.emoji.insert',
+                      {
+                        defaultValue: 'Insertar emoji {{emoji}}',
+                        emoji,
+                      }
+                    )}
+                  >
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          <div className={styles.toolbar}>
+            <div className={styles.toolbarGroup}>
+              <button
+                type="button"
+                ref={emojiTriggerRef}
+                className={styles.actionButton}
+                onClick={handleToggleEmoji}
+                aria-expanded={isEmojiOpen}
+                aria-controls={`${textareaId}-emoji-popover`}
+                disabled={disabled}
+              >
+                {t('community.messages.composer.emoji.open', {
+                  defaultValue: 'Emoji',
+                })}
+              </button>
+              <button
+                type="button"
+                ref={bookButtonRef}
+                className={styles.actionButton}
+                onClick={() => handleOpenModal('book', bookButtonRef)}
+                disabled={disabled}
+              >
+                {t('community.messages.composer.bookModal.trigger', {
+                  defaultValue: 'Adjuntar libro',
+                })}
+              </button>
+              <button
+                type="button"
+                ref={swapButtonRef}
+                className={styles.actionButton}
+                onClick={() => handleOpenModal('swap', swapButtonRef)}
+                disabled={disabled}
+              >
+                {t('community.messages.composer.swapModal.trigger', {
+                  defaultValue: 'Proponer intercambio',
+                })}
+              </button>
+              <button
+                type="button"
+                ref={agreementButtonRef}
+                className={styles.actionButton}
+                onClick={() => handleOpenModal('agreement', agreementButtonRef)}
+                disabled={disabled}
+              >
+                {t('community.messages.composer.agreementModal.trigger', {
+                  defaultValue: 'Propuesta de acuerdo',
+                })}
+              </button>
+            </div>
+            <div className={styles.toolbarGroup}>
+              <button
+                type="submit"
+                className={styles.sendButton}
+                disabled={disabled || !hasDraft}
+                aria-label={t('community.messages.composer.send', {
+                  defaultValue: 'Enviar mensaje',
+                })}
+              >
+                ➤
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+
+      <AttachBookModal
+        open={activeModal === 'book'}
+        myBooks={myBooks}
+        theirBooks={theirBooks}
+        counterpartName={counterpartName}
+        onClose={handleCloseModal}
+        onConfirm={handleAttachBookConfirm}
+      />
+      <SwapProposalModal
+        open={activeModal === 'swap'}
+        myBooks={myBooks}
+        theirBooks={theirBooks}
+        counterpartName={counterpartName}
+        onClose={handleCloseModal}
+        onConfirm={handleSwapConfirm}
+      />
+      <AgreementProposalModal
+        open={activeModal === 'agreement'}
+        myBooks={myBooks}
+        theirBooks={theirBooks}
+        counterpartName={counterpartName}
+        onClose={handleCloseModal}
+        onConfirm={handleAgreementConfirm}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/messages/MessageComposer.tsx
+++ b/frontend/src/components/messages/MessageComposer.tsx
@@ -1,3 +1,4 @@
+import { cx } from '@utils/cx'
 import {
   FormEvent,
   KeyboardEvent,
@@ -9,17 +10,11 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { cx } from '@utils/cx'
-
-import {
-  AgreementDetails,
-  Book,
-  SwapProposalDetails,
-} from './Messages.types'
 import { AgreementProposalModal } from './composer/AgreementProposalModal'
 import { AttachBookModal } from './composer/AttachBookModal'
 import { SwapProposalModal } from './composer/SwapProposalModal'
 import styles from './MessageComposer.module.scss'
+import { AgreementDetails, Book, SwapProposalDetails } from './Messages.types'
 
 type ActiveModal = 'book' | 'swap' | 'agreement' | null
 
@@ -33,6 +28,7 @@ type MessageComposerProps = {
   myBooks: Book[]
   theirBooks: Book[]
   counterpartName: string
+  conversationId: number
 }
 
 const EMOJIS = ['😀', '😁', '😂', '😍', '🤔', '👍', '🎉', '📚']
@@ -47,6 +43,7 @@ export const MessageComposer = ({
   myBooks,
   theirBooks,
   counterpartName,
+  conversationId,
 }: MessageComposerProps) => {
   const { t } = useTranslation()
   const textareaId = useId()
@@ -114,7 +111,7 @@ export const MessageComposer = ({
 
   const handleOpenModal = (
     type: Exclude<ActiveModal, null>,
-    triggerRef: RefObject<HTMLButtonElement>
+    triggerRef: RefObject<HTMLButtonElement | null>
   ) => {
     if (disabled) return
     modalTriggerRef.current = triggerRef.current
@@ -187,7 +184,7 @@ export const MessageComposer = ({
   useEffect(() => {
     closeEmojiPicker()
     setActiveModal(null)
-  }, [myBooks, theirBooks, counterpartName])
+  }, [conversationId])
 
   const hasDraft = draft.trim().length > 0
 
@@ -241,13 +238,10 @@ export const MessageComposer = ({
                     type="button"
                     className={styles.emojiButton}
                     onClick={() => handleEmojiSelect(emoji)}
-                    aria-label={t(
-                      'community.messages.composer.emoji.insert',
-                      {
-                        defaultValue: 'Insertar emoji {{emoji}}',
-                        emoji,
-                      }
-                    )}
+                    aria-label={t('community.messages.composer.emoji.insert', {
+                      defaultValue: 'Insertar emoji {{emoji}}',
+                      emoji,
+                    })}
                   >
                     {emoji}
                   </button>
@@ -263,7 +257,9 @@ export const MessageComposer = ({
                 className={styles.actionButton}
                 onClick={handleToggleEmoji}
                 aria-expanded={isEmojiOpen}
-                aria-controls={`${textareaId}-emoji-popover`}
+                aria-controls={
+                  isEmojiOpen ? `${textareaId}-emoji-popover` : undefined
+                }
                 disabled={disabled}
               >
                 {t('community.messages.composer.emoji.open', {

--- a/frontend/src/components/messages/Messages.mock.ts
+++ b/frontend/src/components/messages/Messages.mock.ts
@@ -10,6 +10,16 @@ export const mockConversations: Conversation[] = [
     },
     badges: [],
     messages: [],
+    myBooks: [
+      {
+        id: 'bot-1',
+        title: 'La biblioteca secreta',
+        author: 'EntreLibros',
+        cover: 'https://covers.openlibrary.org/b/id/9259256-S.jpg',
+        ownership: 'mine',
+      },
+    ],
+    theirBooks: [],
   },
   {
     id: 1,
@@ -82,6 +92,40 @@ export const mockConversations: Conversation[] = [
         time: '4:42 PM',
       },
     ],
+    myBooks: [
+      {
+        id: 'me-1',
+        title: 'El nombre del viento',
+        author: 'Patrick Rothfuss',
+        cover: 'https://covers.openlibrary.org/b/id/9259256-S.jpg',
+        ownership: 'mine',
+      },
+      {
+        id: 'me-2',
+        title: 'La Comunidad del Anillo',
+        author: 'J.R.R. Tolkien',
+        cover: 'https://covers.openlibrary.org/b/id/8231856-S.jpg',
+        ownership: 'mine',
+      },
+    ],
+    theirBooks: [
+      {
+        id: 'samuel-1',
+        title: 'Crónica del pájaro que da cuerda al mundo',
+        author: 'Haruki Murakami',
+        cover: 'https://covers.openlibrary.org/b/id/240726-S.jpg',
+        ownership: 'theirs',
+        ownerName: 'Samuel',
+      },
+      {
+        id: 'samuel-2',
+        title: 'La ciudad y los perros',
+        author: 'Mario Vargas Llosa',
+        cover: 'https://covers.openlibrary.org/b/id/11153227-S.jpg',
+        ownership: 'theirs',
+        ownerName: 'Samuel',
+      },
+    ],
   },
   {
     id: 2,
@@ -98,6 +142,25 @@ export const mockConversations: Conversation[] = [
         role: 'them',
         text: '¡Genial, gracias!',
         time: '1:15 PM',
+      },
+    ],
+    myBooks: [
+      {
+        id: 'me-3',
+        title: 'Rayuela',
+        author: 'Julio Cortázar',
+        cover: 'https://covers.openlibrary.org/b/id/8101340-S.jpg',
+        ownership: 'mine',
+      },
+    ],
+    theirBooks: [
+      {
+        id: 'laura-1',
+        title: 'Middlesex',
+        author: 'Jeffrey Eugenides',
+        cover: 'https://covers.openlibrary.org/b/id/8371281-S.jpg',
+        ownership: 'theirs',
+        ownerName: 'Laura',
       },
     ],
   },
@@ -118,6 +181,25 @@ export const mockConversations: Conversation[] = [
         time: 'Yesterday',
       },
     ],
+    myBooks: [
+      {
+        id: 'me-4',
+        title: 'Dune',
+        author: 'Frank Herbert',
+        cover: 'https://covers.openlibrary.org/b/id/9251992-S.jpg',
+        ownership: 'mine',
+      },
+    ],
+    theirBooks: [
+      {
+        id: 'pablo-1',
+        title: 'Neuromante',
+        author: 'William Gibson',
+        cover: 'https://covers.openlibrary.org/b/id/9255402-S.jpg',
+        ownership: 'theirs',
+        ownerName: 'Pablo',
+      },
+    ],
   },
   {
     id: 4,
@@ -134,6 +216,25 @@ export const mockConversations: Conversation[] = [
         role: 'them',
         text: '¡Guau, suena como un gran libro!',
         time: 'Yesterday',
+      },
+    ],
+    myBooks: [
+      {
+        id: 'me-5',
+        title: 'Fahrenheit 451',
+        author: 'Ray Bradbury',
+        cover: 'https://covers.openlibrary.org/b/id/8081531-S.jpg',
+        ownership: 'mine',
+      },
+    ],
+    theirBooks: [
+      {
+        id: 'sophia-1',
+        title: 'La casa de los espíritus',
+        author: 'Isabel Allende',
+        cover: 'https://covers.openlibrary.org/b/id/8225269-S.jpg',
+        ownership: 'theirs',
+        ownerName: 'Sophia',
       },
     ],
   },

--- a/frontend/src/components/messages/Messages.module.scss
+++ b/frontend/src/components/messages/Messages.module.scss
@@ -207,68 +207,9 @@
 }
 
 .inputArea {
-  display: flex;
-  align-items: center;
-  gap: $spacing-1;
   padding: $spacing-1 $spacing-2;
   background: var(--background-primary);
   border-top: 1px solid var(--border-color);
-}
-
-.inputWrapper {
-  flex: 1;
-  position: relative;
-}
-
-.inputWrapper input {
-  width: calc(100% - $spacing-4 * 2);
-  height: 44px;
-  padding: 0 ($spacing-3 * 2) 0 $spacing-2;
-  border: 1px solid var(--border-color);
-  border-radius: 24px;
-  background: var(--background-primary);
-  color: var(--text-primary);
-
-  &:focus {
-    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
-  }
-}
-
-.inputIcons {
-  position: absolute;
-  top: 50%;
-  right: $spacing-1;
-  transform: translateY(-50%);
-  display: flex;
-}
-
-.inputIcons button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--text-secondary);
-  font-size: 1.2rem;
-}
-
-.sendButton {
-  background: rgb(var(--primary-color-rgb));
-  color: #fff;
-  border: none;
-  border-radius: 10px;
-  padding: 10px 16px;
-  font-weight: 600;
-  transition:
-    transform 0.04s ease,
-    background 0.15s;
-  cursor: pointer;
-
-  &:active {
-    transform: translateY(1px);
-  }
-
-  &:hover {
-    background: var(--primary-dark);
-  }
 }
 
 .placeholder {

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -7,8 +7,8 @@ import { ReactComponent as InfoIcon } from '@src/assets/icons/info.svg'
 
 import { BubbleAgreementConfirmation } from './components/BubbleAgreement/BubbleAgreementConfirmation'
 import { BubbleAgreementProposal } from './components/BubbleAgreement/BubbleAgreementProposal'
-import { BubbleText } from './components/BubbleText/BubbleText'
 import { BubbleSwapProposal } from './components/BubbleSwap/BubbleSwapProposal'
+import { BubbleText } from './components/BubbleText/BubbleText'
 import { MessageComposer } from './MessageComposer'
 import styles from './Messages.module.scss'
 import {
@@ -25,9 +25,8 @@ const isTextMessage = (message: Message): message is TextMessage =>
 
 export const Messages = () => {
   const { t } = useTranslation()
-  const [conversations, setConversations] = useState<Conversation[]>(
-    mockConversations
-  )
+  const [conversations, setConversations] =
+    useState<Conversation[]>(mockConversations)
   const [selectedId, setSelectedId] = useState<number | null>(
     mockConversations[0]?.id ?? null
   )
@@ -66,7 +65,10 @@ export const Messages = () => {
     return [...staticMessages, ...liveMessages]
   }, [messages, currentUser, selected])
 
-  const appendMessageToConversation = (conversationId: number, message: Message) => {
+  const appendMessageToConversation = (
+    conversationId: number,
+    message: Message
+  ) => {
     setConversations((prev) =>
       prev.map((conv) =>
         conv.id === conversationId
@@ -151,7 +153,6 @@ export const Messages = () => {
       proposal,
     })
   }
-
 
   return (
     <div className={styles.wrapper}>
@@ -349,6 +350,7 @@ export const Messages = () => {
               myBooks={selected.myBooks}
               theirBooks={selected.theirBooks}
               counterpartName={selected.user.name}
+              conversationId={selected.id}
             />
           </div>
         ) : (

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -45,6 +45,7 @@ export const Messages = () => {
     )
     const liveMessages = messages
       .filter((m) => m.channel === selected.user.name)
+      .filter((m) => m.user.id !== currentUser?.id)
       .map((m, idx) => {
         const role: MessageRole = m.user.id === currentUser?.id ? 'me' : 'them'
         const tone: Message['tone'] = role === 'me' ? 'primary' : 'neutral'

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -3,18 +3,20 @@ import { useChatSocket } from '@hooks/socket/useChatSocket'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ReactComponent as AttachIcon } from '@src/assets/icons/attachments.svg'
-import { ReactComponent as EmojiIcon } from '@src/assets/icons/emoji.svg'
 import { ReactComponent as InfoIcon } from '@src/assets/icons/info.svg'
 
 import { BubbleAgreementConfirmation } from './components/BubbleAgreement/BubbleAgreementConfirmation'
 import { BubbleAgreementProposal } from './components/BubbleAgreement/BubbleAgreementProposal'
 import { BubbleText } from './components/BubbleText/BubbleText'
+import { BubbleSwapProposal } from './components/BubbleSwap/BubbleSwapProposal'
+import { MessageComposer } from './MessageComposer'
 import styles from './Messages.module.scss'
 import {
+  AgreementDetails,
   Conversation,
   Message,
   MessageRole,
+  SwapProposalDetails,
   TextMessage,
 } from './Messages.types'
 
@@ -23,11 +25,12 @@ const isTextMessage = (message: Message): message is TextMessage =>
 
 export const Messages = () => {
   const { t } = useTranslation()
-  const [conversations] = useState<Conversation[]>(mockConversations)
+  const [conversations, setConversations] = useState<Conversation[]>(
+    mockConversations
+  )
   const [selectedId, setSelectedId] = useState<number | null>(
     mockConversations[0]?.id ?? null
   )
-  const [text, setText] = useState('')
   const { messages, sendMessage, currentUser, isConnected, error } =
     useChatSocket()
 
@@ -63,11 +66,92 @@ export const Messages = () => {
     return [...staticMessages, ...liveMessages]
   }, [messages, currentUser, selected])
 
-  const handleSend = () => {
-    if (!text.trim() || selectedId === null || !selected) return
-    sendMessage(text.trim(), selected.user.name)
-    setText('')
+  const appendMessageToConversation = (conversationId: number, message: Message) => {
+    setConversations((prev) =>
+      prev.map((conv) =>
+        conv.id === conversationId
+          ? { ...conv, messages: [...conv.messages, message] }
+          : conv
+      )
+    )
   }
+
+  const createBaseMessage = (conversation: Conversation) => {
+    const maxId = conversation.messages.reduce(
+      (maxValue, msg) => Math.max(maxValue, msg.id),
+      0
+    )
+    const nextId = maxId + 1
+
+    return {
+      id: nextId,
+      role: 'me' as const,
+      tone: 'primary' as const,
+      time: new Date().toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    }
+  }
+
+  const handleSendText = (draft: string) => {
+    if (!draft.trim() || !selected || selectedId === null) return
+
+    const baseMessage = createBaseMessage(selected)
+    const newMessage: TextMessage = {
+      ...baseMessage,
+      type: 'text',
+      text: draft.trim(),
+    }
+
+    appendMessageToConversation(selectedId, newMessage)
+    sendMessage(draft.trim(), selected.user.name)
+  }
+
+  const handleAttachBook = (bookId: string, note?: string) => {
+    if (!selected || selectedId === null) return
+
+    const book =
+      selected.myBooks.find((item) => item.id === bookId) ??
+      selected.theirBooks.find((item) => item.id === bookId)
+
+    if (!book) return
+
+    const baseMessage = createBaseMessage(selected)
+    const newMessage: Message = {
+      ...baseMessage,
+      type: 'bookCard',
+      book,
+      text: note?.trim() ? note.trim() : undefined,
+    }
+
+    appendMessageToConversation(selectedId, newMessage)
+  }
+
+  const handleSwapProposal = (details: SwapProposalDetails) => {
+    if (!selected || selectedId === null) return
+
+    const baseMessage = createBaseMessage(selected)
+
+    appendMessageToConversation(selectedId, {
+      ...baseMessage,
+      type: 'swapProposal',
+      swap: details,
+    })
+  }
+
+  const handleAgreementProposal = (proposal: AgreementDetails) => {
+    if (!selected || selectedId === null) return
+
+    const baseMessage = createBaseMessage(selected)
+
+    appendMessageToConversation(selectedId, {
+      ...baseMessage,
+      type: 'agreementProposal',
+      proposal,
+    })
+  }
+
 
   return (
     <div className={styles.wrapper}>
@@ -122,6 +206,16 @@ export const Messages = () => {
                         return t(
                           'community.messages.agreement.confirmation.title'
                         )
+                      }
+                      if (lastMsg.type === 'swapProposal') {
+                        return t('community.messages.swap.proposal.title', {
+                          defaultValue: 'Propuesta de intercambio',
+                        })
+                      }
+                      if (lastMsg.type === 'bookCard') {
+                        return t('community.messages.snippets.sharedBook', {
+                          defaultValue: 'Compartió un libro',
+                        })
                       }
                       if (isTextMessage(lastMsg)) {
                         if (lastMsg.book)
@@ -209,6 +303,18 @@ export const Messages = () => {
                   )
                 }
 
+                if (msg.type === 'swapProposal') {
+                  return (
+                    <BubbleSwapProposal
+                      key={msg.id}
+                      role={msg.role}
+                      tone={msg.tone}
+                      swap={msg.swap}
+                      time={msg.time}
+                    />
+                  )
+                }
+
                 if (msg.type === 'agreementConfirmation') {
                   return (
                     <BubbleAgreementConfirmation
@@ -226,51 +332,24 @@ export const Messages = () => {
                     key={msg.id}
                     role={msg.role}
                     tone={msg.tone}
-                    text={msg.text}
-                    book={msg.book}
+                    text={'text' in msg ? msg.text : undefined}
+                    book={'book' in msg ? msg.book : undefined}
                     time={msg.time}
                   />
                 )
               })}
             </div>
-            <div className={styles.inputArea}>
-              <div className={styles.inputWrapper}>
-                <input
-                  value={text}
-                  onChange={(e) => setText(e.target.value)}
-                  placeholder={t('community.messages.inputPlaceholder', {
-                    defaultValue: 'Escribe un mensaje...',
-                  })}
-                  disabled={!isConnected}
-                />
-                <div className={styles.inputIcons}>
-                  <button
-                    aria-label={t('community.messages.actions.attachments', {
-                      defaultValue: 'Adjuntar archivos',
-                    })}
-                  >
-                    <AttachIcon />
-                  </button>
-                  <button
-                    aria-label={t('community.messages.actions.emoji', {
-                      defaultValue: 'Abrir selector de emojis',
-                    })}
-                  >
-                    <EmojiIcon />
-                  </button>
-                </div>
-              </div>
-              <button
-                aria-label={t('community.messages.actions.send', {
-                  defaultValue: 'Enviar mensaje',
-                })}
-                onClick={handleSend}
-                className={styles.sendButton}
-                disabled={!isConnected}
-              >
-                ➤
-              </button>
-            </div>
+            <MessageComposer
+              className={styles.inputArea}
+              disabled={!isConnected}
+              onSendText={handleSendText}
+              onAttachBook={handleAttachBook}
+              onProposeSwap={handleSwapProposal}
+              onProposeAgreement={handleAgreementProposal}
+              myBooks={selected.myBooks}
+              theirBooks={selected.theirBooks}
+              counterpartName={selected.user.name}
+            />
           </div>
         ) : (
           <div className={styles.placeholder}>

--- a/frontend/src/components/messages/Messages.types.ts
+++ b/frontend/src/components/messages/Messages.types.ts
@@ -1,4 +1,5 @@
 export type Book = {
+  id?: string
   title: string
   author: string
   cover: string
@@ -48,10 +49,29 @@ export type AgreementConfirmationMessage = BaseMessage & {
   confirmedBy: string
 }
 
+export type BookCardMessage = BaseMessage & {
+  type: 'bookCard'
+  book: Book
+  text?: string
+}
+
+export type SwapProposalDetails = {
+  offered: Book
+  requested: Book
+  note?: string
+}
+
+export type SwapProposalMessage = BaseMessage & {
+  type: 'swapProposal'
+  swap: SwapProposalDetails
+}
+
 export type Message =
   | TextMessage
   | AgreementProposalMessage
   | AgreementConfirmationMessage
+  | BookCardMessage
+  | SwapProposalMessage
 
 export type Conversation = {
   id: number
@@ -63,4 +83,6 @@ export type Conversation = {
   }
   badges: ('unread' | 'book' | 'swap')[]
   messages: Message[]
+  myBooks: Book[]
+  theirBooks: Book[]
 }

--- a/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.module.scss
+++ b/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.module.scss
@@ -1,0 +1,47 @@
+@import '@styles/variables';
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: color-mix(in srgb, var(--background-card) 92%, #000 8%);
+  border-radius: rem(10px);
+  padding: $spacing-1 $spacing-2;
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.bookTitle {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.bookAuthor {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.note {
+  padding: $spacing-1 $spacing-2;
+  border-left: 3px solid rgb(var(--primary-color-rgb));
+  background: color-mix(in srgb, var(--background-card) 88%, #000 12%);
+  border-radius: rem(10px);
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.time {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}

--- a/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.tsx
+++ b/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.tsx
@@ -17,7 +17,10 @@ type BubbleSwapProposalProps = {
   time?: string
 } & Pick<BubbleBaseProps, 'className'>
 
-const buildOwnershipLabel = (book: Book, t: (key: string, options?: Record<string, unknown>) => string) => {
+const buildOwnershipLabel = (
+  book: Book,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
   if (!book.ownership) return null
   if (book.ownership === 'mine') {
     return t('community.messages.bookBubble.mine', {
@@ -27,9 +30,11 @@ const buildOwnershipLabel = (book: Book, t: (key: string, options?: Record<strin
 
   return t('community.messages.bookBubble.theirs', {
     defaultValue: 'Libro de {{name}}',
-    name: book.ownerName ?? t('community.messages.bookBubble.otherUser', {
-      defaultValue: 'la otra persona',
-    }),
+    name:
+      book.ownerName ??
+      t('community.messages.bookBubble.otherUser', {
+        defaultValue: 'la otra persona',
+      }),
   })
 }
 

--- a/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.tsx
+++ b/frontend/src/components/messages/components/BubbleSwap/BubbleSwapProposal.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from 'react-i18next'
+
+import { Book, SwapProposalDetails } from '../../Messages.types'
+import {
+  BubbleBase,
+  BubbleBaseProps,
+  BubbleRole,
+  BubbleTone,
+} from '../BubbleBase/BubbleBase'
+
+import styles from './BubbleSwapProposal.module.scss'
+
+type BubbleSwapProposalProps = {
+  role?: BubbleRole
+  tone?: BubbleTone
+  swap: SwapProposalDetails
+  time?: string
+} & Pick<BubbleBaseProps, 'className'>
+
+const buildOwnershipLabel = (book: Book, t: (key: string, options?: Record<string, unknown>) => string) => {
+  if (!book.ownership) return null
+  if (book.ownership === 'mine') {
+    return t('community.messages.bookBubble.mine', {
+      defaultValue: 'Tu libro',
+    })
+  }
+
+  return t('community.messages.bookBubble.theirs', {
+    defaultValue: 'Libro de {{name}}',
+    name: book.ownerName ?? t('community.messages.bookBubble.otherUser', {
+      defaultValue: 'la otra persona',
+    }),
+  })
+}
+
+export const BubbleSwapProposal = ({
+  role = 'them',
+  tone = 'neutral',
+  swap,
+  time,
+  className,
+}: BubbleSwapProposalProps) => {
+  const { t } = useTranslation()
+  const offeredOwnership = buildOwnershipLabel(swap.offered, t)
+  const requestedOwnership = buildOwnershipLabel(swap.requested, t)
+
+  const ariaLabel = t('community.messages.swap.proposal.ariaLabel', {
+    defaultValue:
+      'Propuesta de intercambio: ofrecés {{offered}} por {{requested}}',
+    offered: swap.offered.title,
+    requested: swap.requested.title,
+  })
+
+  return (
+    <BubbleBase
+      role={role}
+      tone={tone}
+      ariaLabel={ariaLabel}
+      className={className}
+      meta={time ? <span className={styles.time}>{time}</span> : null}
+      header={t('community.messages.swap.proposal.title', {
+        defaultValue: 'Propuesta de intercambio',
+      })}
+    >
+      <div className={styles.content}>
+        <div className={styles.section}>
+          <span className={styles.label}>
+            {t('community.messages.swap.proposal.offered', {
+              defaultValue: 'Ofrecés',
+            })}
+          </span>
+          {offeredOwnership ? (
+            <span className={styles.bookAuthor}>{offeredOwnership}</span>
+          ) : null}
+          <span className={styles.bookTitle}>{swap.offered.title}</span>
+          <span className={styles.bookAuthor}>{swap.offered.author}</span>
+        </div>
+        <div className={styles.section}>
+          <span className={styles.label}>
+            {t('community.messages.swap.proposal.requested', {
+              defaultValue: 'Querés recibir',
+            })}
+          </span>
+          {requestedOwnership ? (
+            <span className={styles.bookAuthor}>{requestedOwnership}</span>
+          ) : null}
+          <span className={styles.bookTitle}>{swap.requested.title}</span>
+          <span className={styles.bookAuthor}>{swap.requested.author}</span>
+        </div>
+        {swap.note ? <p className={styles.note}>{swap.note}</p> : null}
+      </div>
+    </BubbleBase>
+  )
+}

--- a/frontend/src/components/messages/components/BubbleText/BubbleText.module.scss
+++ b/frontend/src/components/messages/components/BubbleText/BubbleText.module.scss
@@ -7,8 +7,7 @@
 
 .bookCard {
   display: flex;
-  gap: $spacing-2;
-  margin-top: $spacing-1;
+  gap: $spacing-1;
   padding: $spacing-1;
   border-radius: 10px;
   background: inherit;

--- a/frontend/src/components/messages/composer/AgreementProposalModal.tsx
+++ b/frontend/src/components/messages/composer/AgreementProposalModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, RefObject, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AgreementDetails, Book } from '../Messages.types'
@@ -62,15 +62,14 @@ export const AgreementProposalModal = ({
   }
 
   const allBooks = [...myBooks, ...theirBooks]
-  const canSubmit =
-    Boolean(
-      meetingPoint.trim() &&
-        area.trim() &&
-        date.trim() &&
-        time.trim() &&
-        bookId &&
-        allBooks.some((book) => book.id === bookId)
-    )
+  const canSubmit = Boolean(
+    meetingPoint.trim() &&
+      area.trim() &&
+      date.trim() &&
+      time.trim() &&
+      bookId &&
+      allBooks.some((book) => book.id === bookId)
+  )
 
   return (
     <ComposerModal
@@ -86,7 +85,7 @@ export const AgreementProposalModal = ({
         defaultValue: 'Cerrar',
       })}
       onClose={onClose}
-      initialFocusRef={meetingPointRef}
+      initialFocusRef={meetingPointRef as RefObject<HTMLElement>}
     >
       <form className={styles.form} onSubmit={handleSubmit}>
         <div className={styles.field}>

--- a/frontend/src/components/messages/composer/AgreementProposalModal.tsx
+++ b/frontend/src/components/messages/composer/AgreementProposalModal.tsx
@@ -1,0 +1,250 @@
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { AgreementDetails, Book } from '../Messages.types'
+
+import styles from './ComposerForm.module.scss'
+import { ComposerModal } from './ComposerModal'
+
+type AgreementProposalModalProps = {
+  open: boolean
+  myBooks: Book[]
+  theirBooks: Book[]
+  counterpartName: string
+  onClose: () => void
+  onConfirm: (details: AgreementDetails) => void
+}
+
+export const AgreementProposalModal = ({
+  open,
+  myBooks,
+  theirBooks,
+  counterpartName,
+  onClose,
+  onConfirm,
+}: AgreementProposalModalProps) => {
+  const { t } = useTranslation()
+  const meetingPointRef = useRef<HTMLInputElement>(null)
+  const [meetingPoint, setMeetingPoint] = useState('')
+  const [area, setArea] = useState('')
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+  const [bookId, setBookId] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+
+    setMeetingPoint('')
+    setArea('')
+    setDate('')
+    setTime('')
+    const fallbackBook = myBooks[0] ?? theirBooks[0]
+    setBookId(fallbackBook?.id ?? '')
+  }, [open, myBooks, theirBooks])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const selectedBook =
+      myBooks.find((book) => book.id === bookId) ??
+      theirBooks.find((book) => book.id === bookId)
+
+    if (!selectedBook) return
+
+    onConfirm({
+      meetingPoint: meetingPoint.trim(),
+      area: area.trim(),
+      date: date.trim(),
+      time: time.trim(),
+      bookTitle: selectedBook.title,
+    })
+    onClose()
+  }
+
+  const allBooks = [...myBooks, ...theirBooks]
+  const canSubmit =
+    Boolean(
+      meetingPoint.trim() &&
+        area.trim() &&
+        date.trim() &&
+        time.trim() &&
+        bookId &&
+        allBooks.some((book) => book.id === bookId)
+    )
+
+  return (
+    <ComposerModal
+      open={open}
+      title={t('community.messages.composer.agreementModal.title', {
+        defaultValue: 'Propuesta de acuerdo',
+      })}
+      description={t('community.messages.composer.agreementModal.description', {
+        defaultValue:
+          'Definí un punto de encuentro y horario para cerrar el intercambio.',
+      })}
+      closeLabel={t('community.messages.composer.close', {
+        defaultValue: 'Cerrar',
+      })}
+      onClose={onClose}
+      initialFocusRef={meetingPointRef}
+    >
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-agreement-meeting">
+            {t('community.messages.composer.agreementModal.meetingLabel', {
+              defaultValue: 'Punto de encuentro',
+            })}
+          </label>
+          <input
+            id="composer-agreement-meeting"
+            ref={meetingPointRef}
+            className={styles.input}
+            value={meetingPoint}
+            onChange={(event) => setMeetingPoint(event.target.value)}
+            placeholder={t(
+              'community.messages.composer.agreementModal.meetingPlaceholder',
+              {
+                defaultValue: 'Ej. Café de la plaza',
+              }
+            )}
+            required
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-agreement-area">
+            {t('community.messages.composer.agreementModal.areaLabel', {
+              defaultValue: 'Zona o barrio',
+            })}
+          </label>
+          <input
+            id="composer-agreement-area"
+            className={styles.input}
+            value={area}
+            onChange={(event) => setArea(event.target.value)}
+            placeholder={t(
+              'community.messages.composer.agreementModal.areaPlaceholder',
+              {
+                defaultValue: 'Ej. Nervión (Sevilla)',
+              }
+            )}
+            required
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-agreement-date">
+            {t('community.messages.composer.agreementModal.dateLabel', {
+              defaultValue: 'Día sugerido',
+            })}
+          </label>
+          <input
+            id="composer-agreement-date"
+            className={styles.input}
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+            placeholder={t(
+              'community.messages.composer.agreementModal.datePlaceholder',
+              {
+                defaultValue: 'Ej. Martes 12/03',
+              }
+            )}
+            required
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-agreement-time">
+            {t('community.messages.composer.agreementModal.timeLabel', {
+              defaultValue: 'Horario',
+            })}
+          </label>
+          <input
+            id="composer-agreement-time"
+            className={styles.input}
+            value={time}
+            onChange={(event) => setTime(event.target.value)}
+            placeholder={t(
+              'community.messages.composer.agreementModal.timePlaceholder',
+              {
+                defaultValue: 'Ej. 19:00',
+              }
+            )}
+            required
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-agreement-book">
+            {t('community.messages.composer.agreementModal.bookLabel', {
+              defaultValue: 'Libro a intercambiar',
+            })}
+          </label>
+          <select
+            id="composer-agreement-book"
+            className={styles.select}
+            value={bookId}
+            onChange={(event) => setBookId(event.target.value)}
+            required
+          >
+            {allBooks.length > 0 ? null : (
+              <option value="">
+                {t('community.messages.composer.agreementModal.noBooks', {
+                  defaultValue: 'No hay libros cargados en la conversación.',
+                })}
+              </option>
+            )}
+            {myBooks.length > 0 ? (
+              <optgroup
+                label={t('community.messages.composer.bookModal.mine', {
+                  defaultValue: 'Mis libros',
+                })}
+              >
+                {myBooks.map((book) => (
+                  <option key={book.id} value={book.id}>
+                    {book.title}
+                  </option>
+                ))}
+              </optgroup>
+            ) : null}
+            {theirBooks.length > 0 ? (
+              <optgroup
+                label={t('community.messages.composer.bookModal.theirs', {
+                  defaultValue: 'Libros de {{name}}',
+                  name: counterpartName,
+                })}
+              >
+                {theirBooks.map((book) => (
+                  <option key={book.id} value={book.id}>
+                    {book.title}
+                  </option>
+                ))}
+              </optgroup>
+            ) : null}
+          </select>
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.buttonSecondary}
+            onClick={onClose}
+          >
+            {t('community.messages.composer.cancel', {
+              defaultValue: 'Cancelar',
+            })}
+          </button>
+          <button
+            type="submit"
+            className={styles.buttonPrimary}
+            disabled={!canSubmit}
+          >
+            {t('community.messages.composer.agreementModal.submit', {
+              defaultValue: 'Enviar propuesta',
+            })}
+          </button>
+        </div>
+      </form>
+    </ComposerModal>
+  )
+}

--- a/frontend/src/components/messages/composer/AttachBookModal.tsx
+++ b/frontend/src/components/messages/composer/AttachBookModal.tsx
@@ -1,0 +1,160 @@
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Book } from '../Messages.types'
+
+import styles from './ComposerForm.module.scss'
+import { ComposerModal } from './ComposerModal'
+
+type AttachBookModalProps = {
+  open: boolean
+  myBooks: Book[]
+  theirBooks: Book[]
+  counterpartName: string
+  onClose: () => void
+  onConfirm: (bookId: string, note?: string) => void
+}
+
+export const AttachBookModal = ({
+  open,
+  myBooks,
+  theirBooks,
+  counterpartName,
+  onClose,
+  onConfirm,
+}: AttachBookModalProps) => {
+  const { t } = useTranslation()
+  const selectRef = useRef<HTMLSelectElement>(null)
+  const [selectedBookId, setSelectedBookId] = useState('')
+  const [note, setNote] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+
+    const firstBook = myBooks[0] ?? theirBooks[0]
+    setSelectedBookId(firstBook?.id ?? '')
+    setNote('')
+  }, [open, myBooks, theirBooks])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedBookId) return
+
+    const cleanNote = note.trim()
+    onConfirm(selectedBookId, cleanNote ? cleanNote : undefined)
+    onClose()
+  }
+
+  const hasBooks = myBooks.length > 0 || theirBooks.length > 0
+
+  return (
+    <ComposerModal
+      open={open}
+      title={t('community.messages.composer.bookModal.title', {
+        defaultValue: 'Adjuntar libro',
+      })}
+      description={t('community.messages.composer.bookModal.description', {
+        defaultValue: 'Compartí una ficha de libro dentro de la conversación.',
+      })}
+      closeLabel={t('community.messages.composer.close', {
+        defaultValue: 'Cerrar',
+      })}
+      onClose={onClose}
+      initialFocusRef={selectRef}
+    >
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-book-select">
+            {t('community.messages.composer.bookModal.bookLabel', {
+              defaultValue: 'Elegí un libro',
+            })}
+          </label>
+          <select
+            id="composer-book-select"
+            ref={selectRef}
+            className={styles.select}
+            value={selectedBookId}
+            onChange={(event) => setSelectedBookId(event.target.value)}
+            required
+          >
+            {hasBooks ? null : (
+              <option value="">
+                {t('community.messages.composer.bookModal.empty', {
+                  defaultValue: 'No hay libros disponibles',
+                })}
+              </option>
+            )}
+            {myBooks.length > 0 ? (
+              <optgroup
+                label={t('community.messages.composer.bookModal.mine', {
+                  defaultValue: 'Mis libros',
+                })}
+              >
+                {myBooks.map((book) => (
+                  <option key={book.id} value={book.id}>
+                    {book.title}
+                  </option>
+                ))}
+              </optgroup>
+            ) : null}
+            {theirBooks.length > 0 ? (
+              <optgroup
+                label={t('community.messages.composer.bookModal.theirs', {
+                  defaultValue: 'Libros de {{name}}',
+                  name: counterpartName,
+                })}
+              >
+                {theirBooks.map((book) => (
+                  <option key={book.id} value={book.id}>
+                    {book.title}
+                  </option>
+                ))}
+              </optgroup>
+            ) : null}
+          </select>
+          <p className={styles.helperText}>
+            {t('community.messages.composer.bookModal.helper', {
+              defaultValue: 'Podés añadir una nota opcional para darle contexto.',
+            })}
+          </p>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-book-note">
+            {t('community.messages.composer.bookModal.noteLabel', {
+              defaultValue: 'Nota (opcional)',
+            })}
+          </label>
+          <textarea
+            id="composer-book-note"
+            className={styles.textarea}
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.buttonSecondary}
+            onClick={onClose}
+          >
+            {t('community.messages.composer.cancel', {
+              defaultValue: 'Cancelar',
+            })}
+          </button>
+          <button
+            type="submit"
+            className={styles.buttonPrimary}
+            disabled={!selectedBookId}
+          >
+            {t('community.messages.composer.bookModal.submit', {
+              defaultValue: 'Adjuntar',
+            })}
+          </button>
+        </div>
+      </form>
+    </ComposerModal>
+  )
+}

--- a/frontend/src/components/messages/composer/AttachBookModal.tsx
+++ b/frontend/src/components/messages/composer/AttachBookModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, RefObject, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Book } from '../Messages.types'
@@ -60,7 +60,7 @@ export const AttachBookModal = ({
         defaultValue: 'Cerrar',
       })}
       onClose={onClose}
-      initialFocusRef={selectRef}
+      initialFocusRef={selectRef as RefObject<HTMLElement>}
     >
       <form className={styles.form} onSubmit={handleSubmit}>
         <div className={styles.field}>
@@ -114,7 +114,8 @@ export const AttachBookModal = ({
           </select>
           <p className={styles.helperText}>
             {t('community.messages.composer.bookModal.helper', {
-              defaultValue: 'Podés añadir una nota opcional para darle contexto.',
+              defaultValue:
+                'Podés añadir una nota opcional para darle contexto.',
             })}
           </p>
         </div>

--- a/frontend/src/components/messages/composer/ComposerForm.module.scss
+++ b/frontend/src/components/messages/composer/ComposerForm.module.scss
@@ -1,0 +1,85 @@
+@import '@styles/variables';
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: rem(10px);
+  padding: $spacing-2;
+  background: var(--background-primary);
+  color: var(--text-primary);
+  font: inherit;
+  resize: vertical;
+  min-height: rem(42px);
+
+  &:focus {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+  }
+}
+
+.textarea {
+  min-height: rem(72px);
+}
+
+.helperText {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-1;
+}
+
+.buttonSecondary,
+.buttonPrimary {
+  border-radius: rem(10px);
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.04s ease;
+}
+
+.buttonSecondary {
+  border: 1px solid var(--border-color);
+  background: none;
+  color: var(--text-secondary);
+
+  &:hover {
+    background: color-mix(in srgb, var(--background-card) 92%, #000 8%);
+  }
+}
+
+.buttonPrimary {
+  border: none;
+  background: rgb(var(--primary-color-rgb));
+  color: #fff;
+
+  &:hover {
+    background: var(--primary-dark);
+  }
+
+  &:disabled {
+    background: color-mix(in srgb, var(--primary-color) 45%, #000 55%);
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/components/messages/composer/ComposerForm.module.scss
+++ b/frontend/src/components/messages/composer/ComposerForm.module.scss
@@ -20,10 +20,9 @@
 .input,
 .select,
 .textarea {
-  width: 100%;
   border: 1px solid var(--border-color);
   border-radius: rem(10px);
-  padding: $spacing-2;
+  padding: $spacing-1;
   background: var(--background-primary);
   color: var(--text-primary);
   font: inherit;
@@ -56,7 +55,9 @@
   padding: 10px 18px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease, transform 0.04s ease;
+  transition:
+    background 0.15s ease,
+    transform 0.04s ease;
 }
 
 .buttonSecondary {

--- a/frontend/src/components/messages/composer/ComposerModal.module.scss
+++ b/frontend/src/components/messages/composer/ComposerModal.module.scss
@@ -3,7 +3,7 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgb(0 0 0 / 45%);
   display: grid;
   place-items: center;
   z-index: 1000;
@@ -11,11 +11,11 @@
 }
 
 .dialog {
-  width: min(420px, 100%);
+  width: max(500px, 60vw);
   background: var(--background-primary);
   color: var(--text-primary);
   border-radius: rem(16px);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 18px 36px rgb(0 0 0 / 24%);
   display: flex;
   flex-direction: column;
   max-height: 95vh;

--- a/frontend/src/components/messages/composer/ComposerModal.module.scss
+++ b/frontend/src/components/messages/composer/ComposerModal.module.scss
@@ -1,0 +1,63 @@
+@import '@styles/variables';
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+  padding: $spacing-2;
+}
+
+.dialog {
+  width: min(420px, 100%);
+  background: var(--background-primary);
+  color: var(--text-primary);
+  border-radius: rem(16px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
+  display: flex;
+  flex-direction: column;
+  max-height: 95vh;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-1;
+  padding: $spacing-2;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.description {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.body {
+  padding: $spacing-2;
+  overflow-y: auto;
+}
+
+.body > * {
+  width: 100%;
+}

--- a/frontend/src/components/messages/composer/ComposerModal.tsx
+++ b/frontend/src/components/messages/composer/ComposerModal.tsx
@@ -74,7 +74,11 @@ export const ComposerModal = ({
               </p>
             ) : null}
           </div>
-          <button type="button" onClick={onClose} className={styles.closeButton}>
+          <button
+            type="button"
+            onClick={onClose}
+            className={styles.closeButton}
+          >
             {closeLabel}
           </button>
         </header>

--- a/frontend/src/components/messages/composer/ComposerModal.tsx
+++ b/frontend/src/components/messages/composer/ComposerModal.tsx
@@ -1,0 +1,85 @@
+import { ReactNode, RefObject, useEffect, useId } from 'react'
+
+import styles from './ComposerModal.module.scss'
+
+type ComposerModalProps = {
+  open: boolean
+  title: string
+  description?: string
+  children: ReactNode
+  onClose: () => void
+  closeLabel: string
+  initialFocusRef?: RefObject<HTMLElement>
+}
+
+export const ComposerModal = ({
+  open,
+  title,
+  description,
+  children,
+  onClose,
+  closeLabel,
+  initialFocusRef,
+}: ComposerModalProps) => {
+  const titleId = useId()
+  const descriptionId = useId()
+
+  useEffect(() => {
+    if (!open) return
+
+    const focusElement = initialFocusRef?.current
+    if (focusElement) {
+      requestAnimationFrame(() => {
+        focusElement.focus()
+      })
+    }
+  }, [open, initialFocusRef])
+
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className={styles.overlay} role="presentation" onClick={onClose}>
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className={styles.header}>
+          <div>
+            <h2 id={titleId} className={styles.title}>
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className={styles.description}>
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <button type="button" onClick={onClose} className={styles.closeButton}>
+            {closeLabel}
+          </button>
+        </header>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/messages/composer/SwapProposalModal.tsx
+++ b/frontend/src/components/messages/composer/SwapProposalModal.tsx
@@ -1,0 +1,175 @@
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Book, SwapProposalDetails } from '../Messages.types'
+
+import styles from './ComposerForm.module.scss'
+import { ComposerModal } from './ComposerModal'
+
+type SwapProposalModalProps = {
+  open: boolean
+  myBooks: Book[]
+  theirBooks: Book[]
+  counterpartName: string
+  onClose: () => void
+  onConfirm: (details: SwapProposalDetails) => void
+}
+
+export const SwapProposalModal = ({
+  open,
+  myBooks,
+  theirBooks,
+  counterpartName,
+  onClose,
+  onConfirm,
+}: SwapProposalModalProps) => {
+  const { t } = useTranslation()
+  const offeredRef = useRef<HTMLSelectElement>(null)
+  const [offeredId, setOfferedId] = useState('')
+  const [requestedId, setRequestedId] = useState('')
+  const [note, setNote] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+
+    setOfferedId(myBooks[0]?.id ?? '')
+    setRequestedId(theirBooks[0]?.id ?? '')
+    setNote('')
+  }, [open, myBooks, theirBooks])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const offered = myBooks.find((book) => book.id === offeredId)
+    const requested = theirBooks.find((book) => book.id === requestedId)
+    if (!offered || !requested) return
+
+    const cleanNote = note.trim()
+    onConfirm({
+      offered,
+      requested,
+      note: cleanNote ? cleanNote : undefined,
+    })
+    onClose()
+  }
+
+  const canSubmit = Boolean(offeredId && requestedId)
+
+  return (
+    <ComposerModal
+      open={open}
+      title={t('community.messages.composer.swapModal.title', {
+        defaultValue: 'Propuesta de intercambio',
+      })}
+      description={t('community.messages.composer.swapModal.description', {
+        defaultValue:
+          'Elegí qué libro ofrecés y cuál te gustaría recibir a cambio.',
+      })}
+      closeLabel={t('community.messages.composer.close', {
+        defaultValue: 'Cerrar',
+      })}
+      onClose={onClose}
+      initialFocusRef={offeredRef}
+    >
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-swap-offered">
+            {t('community.messages.composer.swapModal.offeredLabel', {
+              defaultValue: 'Ofrecés',
+            })}
+          </label>
+          <select
+            id="composer-swap-offered"
+            ref={offeredRef}
+            className={styles.select}
+            value={offeredId}
+            onChange={(event) => setOfferedId(event.target.value)}
+            required
+          >
+            {myBooks.length > 0 ? null : (
+              <option value="">
+                {t('community.messages.composer.swapModal.noMine', {
+                  defaultValue: 'No tenés libros disponibles para intercambio.',
+                })}
+              </option>
+            )}
+            {myBooks.map((book) => (
+              <option key={book.id} value={book.id}>
+                {book.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-swap-requested">
+            {t('community.messages.composer.swapModal.requestedLabel', {
+              defaultValue: 'Querés recibir',
+            })}
+          </label>
+          <select
+            id="composer-swap-requested"
+            className={styles.select}
+            value={requestedId}
+            onChange={(event) => setRequestedId(event.target.value)}
+            required
+          >
+            {theirBooks.length > 0 ? null : (
+              <option value="">
+                {t('community.messages.composer.swapModal.noTheirs', {
+                  defaultValue: 'La otra persona no tiene libros publicados.',
+                })}
+              </option>
+            )}
+            {theirBooks.map((book) => (
+              <option key={book.id} value={book.id}>
+                {book.title}
+              </option>
+            ))}
+          </select>
+          <p className={styles.helperText}>
+            {t('community.messages.composer.swapModal.helper', {
+              defaultValue: 'Las propuestas se guardan en la conversación para que ambos las revisen.',
+            })}
+          </p>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="composer-swap-note">
+            {t('community.messages.composer.swapModal.noteLabel', {
+              defaultValue: 'Mensaje adicional (opcional)',
+            })}
+          </label>
+          <textarea
+            id="composer-swap-note"
+            className={styles.textarea}
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.buttonSecondary}
+            onClick={onClose}
+          >
+            {t('community.messages.composer.cancel', {
+              defaultValue: 'Cancelar',
+            })}
+          </button>
+          <button
+            type="submit"
+            className={styles.buttonPrimary}
+            disabled={!canSubmit}
+          >
+            {t('community.messages.composer.swapModal.submit', {
+              defaultValue: 'Enviar propuesta',
+            })}
+          </button>
+        </div>
+      </form>
+    </ComposerModal>
+  )
+}

--- a/frontend/src/components/messages/composer/SwapProposalModal.tsx
+++ b/frontend/src/components/messages/composer/SwapProposalModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, RefObject, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Book, SwapProposalDetails } from '../Messages.types'
@@ -19,7 +19,6 @@ export const SwapProposalModal = ({
   open,
   myBooks,
   theirBooks,
-  counterpartName,
   onClose,
   onConfirm,
 }: SwapProposalModalProps) => {
@@ -69,7 +68,7 @@ export const SwapProposalModal = ({
         defaultValue: 'Cerrar',
       })}
       onClose={onClose}
-      initialFocusRef={offeredRef}
+      initialFocusRef={offeredRef as RefObject<HTMLElement>}
     >
       <form className={styles.form} onSubmit={handleSubmit}>
         <div className={styles.field}>
@@ -129,7 +128,8 @@ export const SwapProposalModal = ({
           </select>
           <p className={styles.helperText}>
             {t('community.messages.composer.swapModal.helper', {
-              defaultValue: 'Las propuestas se guardan en la conversación para que ambos las revisen.',
+              defaultValue:
+                'Las propuestas se guardan en la conversación para que ambos las revisen.',
             })}
           </p>
         </div>

--- a/frontend/tests/components/messages/Messages.test.tsx
+++ b/frontend/tests/components/messages/Messages.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { Messages } from '@components/messages/Messages'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -27,10 +27,10 @@ describe('Messages component', () => {
     renderWithProviders(<Messages />)
 
     expect(screen.getByText(/desconectado/i)).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Escribe un mensaje...')).toBeDisabled()
+    expect(screen.getByPlaceholderText('Escribí un mensaje...')).toBeDisabled()
   })
 
-  test('renders selected conversation and sends new messages', () => {
+  test('renders selected conversation and sends new messages with emoji', async () => {
     const sendMessage = vi.fn()
     const now = new Date('2025-03-18T12:00:00Z').toISOString()
     useChatSocketMock.mockReturnValue({
@@ -57,11 +57,97 @@ describe('Messages component', () => {
     expect(conversationItems[1].className).toContain('conversationItemActive')
     expect(screen.getByText('Mensaje en vivo')).toBeInTheDocument()
 
-    const input = screen.getByPlaceholderText('Escribe un mensaje...')
-    fireEvent.change(input, { target: { value: 'Hola Bot' } })
+    const textarea = screen.getByPlaceholderText('Escribí un mensaje...')
+    fireEvent.change(textarea, { target: { value: 'Hola' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Emoji' }))
+    const emojiButton = screen.getByRole('button', {
+      name: 'Insertar emoji 😀',
+    })
+    fireEvent.click(emojiButton)
+    expect(textarea).toHaveValue('Hola😀')
     fireEvent.click(screen.getByRole('button', { name: 'Enviar mensaje' }))
 
-    expect(sendMessage).toHaveBeenCalledWith('Hola Bot', 'Samuel')
-    expect(input).toHaveValue('')
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith('Hola😀', 'Samuel')
+    })
+    expect(textarea).toHaveValue('')
+    expect(screen.getAllByText('Hola😀').length).toBeGreaterThan(0)
+  })
+
+  test('allows attaching a book with contextual note', () => {
+    useChatSocketMock.mockReturnValue({
+      messages: [],
+      sendMessage: vi.fn(),
+      currentUser: { id: 1, name: 'Me' },
+      isConnected: true,
+      error: null,
+    })
+
+    renderWithProviders(<Messages />)
+
+    fireEvent.click(screen.getByText('Samuel'))
+    fireEvent.click(screen.getByRole('button', { name: 'Adjuntar libro' }))
+
+    const modal = screen.getByRole('dialog', { name: /adjuntar libro/i })
+    fireEvent.change(screen.getByLabelText('Elegí un libro'), {
+      target: { value: 'me-2' },
+    })
+    fireEvent.change(screen.getByLabelText('Nota (opcional)'), {
+      target: { value: '¡Te va a gustar!' },
+    })
+    fireEvent.click(within(modal).getByRole('button', { name: 'Adjuntar' }))
+
+    expect(screen.getByText('La Comunidad del Anillo')).toBeInTheDocument()
+    expect(screen.getByText('¡Te va a gustar!')).toBeInTheDocument()
+  })
+
+  test('creates swap and agreement proposals through modals', () => {
+    useChatSocketMock.mockReturnValue({
+      messages: [],
+      sendMessage: vi.fn(),
+      currentUser: { id: 1, name: 'Me' },
+      isConnected: true,
+      error: null,
+    })
+
+    renderWithProviders(<Messages />)
+
+    fireEvent.click(screen.getByText('Samuel'))
+
+    // Swap proposal
+    fireEvent.click(screen.getByRole('button', { name: 'Proponer intercambio' }))
+    const swapModal = screen.getByRole('dialog', { name: /propuesta de intercambio/i })
+    fireEvent.change(within(swapModal).getByLabelText('Mensaje adicional (opcional)'), {
+      target: { value: '¿Te parece el viernes?' },
+    })
+    fireEvent.click(within(swapModal).getByRole('button', { name: 'Enviar propuesta' }))
+
+    expect(screen.getAllByText('Ofrecés')[0]).toBeInTheDocument()
+    expect(screen.getByText('¿Te parece el viernes?')).toBeInTheDocument()
+
+    // Agreement proposal
+    fireEvent.click(screen.getByRole('button', { name: 'Propuesta de acuerdo' }))
+    const agreementModal = screen.getByRole('dialog', { name: /propuesta de acuerdo/i })
+    fireEvent.change(within(agreementModal).getByLabelText('Punto de encuentro'), {
+      target: { value: 'Biblioteca central' },
+    })
+    fireEvent.change(within(agreementModal).getByLabelText('Zona o barrio'), {
+      target: { value: 'Centro' },
+    })
+    fireEvent.change(within(agreementModal).getByLabelText('Día sugerido'), {
+      target: { value: 'Viernes 14' },
+    })
+    fireEvent.change(within(agreementModal).getByLabelText('Horario'), {
+      target: { value: '18:00' },
+    })
+    fireEvent.change(within(agreementModal).getByLabelText('Libro a intercambiar'), {
+      target: { value: 'me-1' },
+    })
+    fireEvent.click(within(agreementModal).getByRole('button', { name: 'Enviar propuesta' }))
+
+    expect(
+      screen.getByText('Biblioteca central — Centro', { exact: false })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Viernes 14 · 18:00')).toBeInTheDocument()
   })
 })

--- a/frontend/tests/components/messages/Messages.test.tsx
+++ b/frontend/tests/components/messages/Messages.test.tsx
@@ -115,22 +115,38 @@ describe('Messages component', () => {
     fireEvent.click(screen.getByText('Samuel'))
 
     // Swap proposal
-    fireEvent.click(screen.getByRole('button', { name: 'Proponer intercambio' }))
-    const swapModal = screen.getByRole('dialog', { name: /propuesta de intercambio/i })
-    fireEvent.change(within(swapModal).getByLabelText('Mensaje adicional (opcional)'), {
-      target: { value: '¿Te parece el viernes?' },
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Proponer intercambio' })
+    )
+    const swapModal = screen.getByRole('dialog', {
+      name: /propuesta de intercambio/i,
     })
-    fireEvent.click(within(swapModal).getByRole('button', { name: 'Enviar propuesta' }))
+    fireEvent.change(
+      within(swapModal).getByLabelText('Mensaje adicional (opcional)'),
+      {
+        target: { value: '¿Te parece el viernes?' },
+      }
+    )
+    fireEvent.click(
+      within(swapModal).getByRole('button', { name: 'Enviar propuesta' })
+    )
 
     expect(screen.getAllByText('Ofrecés')[0]).toBeInTheDocument()
     expect(screen.getByText('¿Te parece el viernes?')).toBeInTheDocument()
 
     // Agreement proposal
-    fireEvent.click(screen.getByRole('button', { name: 'Propuesta de acuerdo' }))
-    const agreementModal = screen.getByRole('dialog', { name: /propuesta de acuerdo/i })
-    fireEvent.change(within(agreementModal).getByLabelText('Punto de encuentro'), {
-      target: { value: 'Biblioteca central' },
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Propuesta de acuerdo' })
+    )
+    const agreementModal = screen.getByRole('dialog', {
+      name: /propuesta de acuerdo/i,
     })
+    fireEvent.change(
+      within(agreementModal).getByLabelText('Punto de encuentro'),
+      {
+        target: { value: 'Biblioteca central' },
+      }
+    )
     fireEvent.change(within(agreementModal).getByLabelText('Zona o barrio'), {
       target: { value: 'Centro' },
     })
@@ -140,10 +156,15 @@ describe('Messages component', () => {
     fireEvent.change(within(agreementModal).getByLabelText('Horario'), {
       target: { value: '18:00' },
     })
-    fireEvent.change(within(agreementModal).getByLabelText('Libro a intercambiar'), {
-      target: { value: 'me-1' },
-    })
-    fireEvent.click(within(agreementModal).getByRole('button', { name: 'Enviar propuesta' }))
+    fireEvent.change(
+      within(agreementModal).getByLabelText('Libro a intercambiar'),
+      {
+        target: { value: 'me-1' },
+      }
+    )
+    fireEvent.click(
+      within(agreementModal).getByRole('button', { name: 'Enviar propuesta' })
+    )
 
     expect(
       screen.getByText('Biblioteca central — Centro', { exact: false })

--- a/frontend/tests/pages/messages/MessagesPage.test.tsx
+++ b/frontend/tests/pages/messages/MessagesPage.test.tsx
@@ -7,6 +7,6 @@ import { renderWithProviders } from '../../test-utils'
 describe('MessagesPage', () => {
   test('renders message input', () => {
     const { getByPlaceholderText } = renderWithProviders(<MessagesPage />)
-    expect(getByPlaceholderText('Escribe un mensaje...')).toBeInTheDocument()
+    expect(getByPlaceholderText('Escribí un mensaje...')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- replace the inline message textarea with a reusable MessageComposer that supports emoji insertion, book attachments, swap and agreement proposals
- add accessible composer modals, swap bubble UI, and extend message types/mocks/translations for the new card flows
- expand RTL coverage for Messages to exercise emoji insertion and modal submissions, adjust the Messages page placeholder test, and document the milestone in the backlog