### PR TITLE
feat: agregar avisos de mensajes in-app

### DIFF
--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -10,9 +10,11 @@ export async function notifyMessageRecipients(input: {
   conversationId: number;
   senderId: number;
 }): Promise<void> {
-  const { rows } = await query<{ user_id: number }>(
-    `SELECT user_id FROM conversation_participants
-     WHERE conversation_id = $1 AND user_id <> $2`,
+  const { rows } = await query<{ user_id: number; sender_name: string }>(
+    `SELECT recipient.user_id, sender.name AS sender_name
+     FROM conversation_participants recipient
+     JOIN users sender ON sender.id = $2
+     WHERE recipient.conversation_id = $1 AND recipient.user_id <> $2`,
     [input.conversationId, input.senderId]
   );
   await Promise.all(
@@ -23,7 +25,10 @@ export async function notifyMessageRecipients(input: {
         entityId: String(input.conversationId),
         titleKey: 'notifications.message.title',
         bodyKey: 'notifications.message.body',
-        data: { conversationId: input.conversationId },
+        data: {
+          conversationId: input.conversationId,
+          senderName: row.sender_name,
+        },
         idempotencyKey: `message:${input.messageId}:${row.user_id}`,
       })
     )

--- a/frontend/src/assets/i18n/locales/en/common.json
+++ b/frontend/src/assets/i18n/locales/en/common.json
@@ -820,12 +820,16 @@
   },
   "notifications": {
     "title": "Notifications",
+    "open": "Open notifications ({{count}} pending)",
     "loading": "Loading notifications...",
     "error": "Notifications could not be loaded.",
     "empty": "You have no new notifications.",
     "markRead": "Mark as read",
     "message": {
       "title": "New message",
+      "from": "New message from {{name}}",
+      "multipleFrom": "{{count}} new messages from {{name}}",
+      "senderFallback": "a user",
       "body": "You received a message in a conversation."
     },
     "agreement": {

--- a/frontend/src/assets/i18n/locales/es/common.json
+++ b/frontend/src/assets/i18n/locales/es/common.json
@@ -812,12 +812,16 @@
   },
   "notifications": {
     "title": "Notificaciones",
+    "open": "Abrir notificaciones ({{count}} pendientes)",
     "loading": "Cargando notificaciones...",
     "error": "No se pudieron cargar las notificaciones.",
     "empty": "No tenés notificaciones nuevas.",
     "markRead": "Marcar como leída",
     "message": {
       "title": "Nuevo mensaje",
+      "from": "Nuevo mensaje de {{name}}",
+      "multipleFrom": "{{count}} mensajes nuevos de {{name}}",
+      "senderFallback": "un usuario",
       "body": "Recibiste un mensaje en una conversación."
     },
     "agreement": {

--- a/frontend/src/assets/icons/bell.svg
+++ b/frontend/src/assets/icons/bell.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 9a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10 21h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/layout/BaseLayout/BaseLayout.tsx
+++ b/frontend/src/components/layout/BaseLayout/BaseLayout.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@utils/cx'
 import { Outlet } from 'react-router-dom'
 
+import { NotificationBell } from '../../notifications/NotificationBell'
 import { Sidebar } from '../../sidebar/Sidebar'
 
 import styles from './BaseLayout.module.scss'
@@ -21,6 +22,7 @@ export const BaseLayout = ({
   return (
     <div className={containerClass} {...(id ? { id: `${id}-container` } : {})}>
       <Sidebar />
+      <NotificationBell />
       <main {...(id ? { id: `${id}-content` } : {})} className={mainClass}>
         {children || <Outlet />}
       </main>

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -20,6 +20,7 @@ import { useChatSocket } from '@hooks/socket/useChatSocket'
 import { isApiMockMode } from '@utils/runtimeEnv'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router-dom'
 
 import { ReactComponent as InfoIcon } from '@src/assets/icons/info.svg'
 
@@ -114,6 +115,7 @@ function toTextMessage(
 
 export const Messages = () => {
   const { t, i18n } = useTranslation()
+  const location = useLocation()
   const useDemoConversations =
     import.meta.env?.MODE === 'test' ||
     import.meta.env?.PUBLIC_DEMO_MODE === 'true' ||
@@ -164,7 +166,17 @@ export const Messages = () => {
         if (!active) return
         const next = items.map(toConversation)
         setConversations(next)
-        setSelectedId(next[0]?.id ?? null)
+        const requestedConversationId = (
+          location.state as { conversationId?: unknown } | null
+        )?.conversationId
+        const requestedId =
+          typeof requestedConversationId === 'number' &&
+          next.some(
+            (conversation) => conversation.id === requestedConversationId
+          )
+            ? requestedConversationId
+            : null
+        setSelectedId(requestedId ?? next[0]?.id ?? null)
       })
       .catch(() => {
         if (!active) return
@@ -178,7 +190,7 @@ export const Messages = () => {
     return () => {
       active = false
     }
-  }, [conversationReloadKey, useDemoConversations])
+  }, [conversationReloadKey, location.state, useDemoConversations])
 
   const isBotConversation = selected?.isBot === true
 

--- a/frontend/src/components/notifications/NotificationBell.module.scss
+++ b/frontend/src/components/notifications/NotificationBell.module.scss
@@ -1,0 +1,90 @@
+@import '@styles/variables';
+
+.container {
+  position: fixed;
+  top: $spacing-2;
+  right: $spacing-2;
+  z-index: $z-index-fixed;
+}
+
+.trigger {
+  position: relative;
+  display: grid;
+  width: rem(42px);
+  height: rem(42px);
+  place-items: center;
+  color: var(--text-primary);
+  background: var(--background-card);
+  border: rem(1px) solid var(--border-color);
+  border-radius: 50%;
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+
+  svg {
+    width: rem(22px);
+    height: rem(22px);
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: var(--primary-color);
+  }
+}
+
+.count {
+  position: absolute;
+  top: rem(-5px);
+  right: rem(-5px);
+  display: grid;
+  min-width: rem(18px);
+  height: rem(18px);
+  padding: 0 rem(3px);
+  place-items: center;
+  color: #fff;
+  font-size: rem(11px);
+  font-weight: 700;
+  background: var(--color-error);
+  border: rem(2px) solid var(--background-primary);
+  border-radius: 999px;
+}
+
+.panel {
+  position: absolute;
+  top: calc(100% + $spacing-1);
+  right: 0;
+  width: min(rem(320px), calc(100vw - $spacing-4));
+  padding: $spacing-2;
+  background: var(--background-card);
+  border: rem(1px) solid var(--border-color);
+  border-radius: rem(10px);
+  box-shadow: var(--shadow-md);
+
+  h2 {
+    margin: 0 0 $spacing-1;
+    color: var(--text-primary);
+    font-size: $small-font-size;
+  }
+}
+
+.list {
+  display: flex;
+  max-height: min(rem(360px), calc(100vh - rem(100px)));
+  flex-direction: column;
+  gap: $spacing-1;
+  overflow-y: auto;
+}
+
+.item {
+  padding: $spacing-1;
+  color: var(--text-primary);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: rem(6px);
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--toggle-hover);
+  }
+}

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,161 @@
+import { useNotifications } from '@hooks/api/useNotifications'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+import { ReactComponent as BellIcon } from '@src/assets/icons/bell.svg'
+import { useAuth } from '@src/contexts/auth/AuthContext'
+
+import styles from './NotificationBell.module.scss'
+
+type MessageNotification = {
+  id: number
+  conversationId: number
+  senderName: string
+  createdAt: string
+}
+
+type MessageGroup = {
+  conversationId: number
+  senderName: string
+  notifications: MessageNotification[]
+  latestCreatedAt: string
+}
+
+export const NotificationBell = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { data: notifications = [], markRead } = useNotifications({
+    enabled: isAuthenticated,
+  })
+
+  const unreadMessageNotifications = useMemo(
+    () =>
+      notifications.filter(
+        (notification) =>
+          notification.kind === 'message' && !notification.readAt
+      ),
+    [notifications]
+  )
+
+  const messageGroups = useMemo(() => {
+    const groups = new Map<number, MessageGroup>()
+    unreadMessageNotifications.forEach((notification) => {
+      const conversationId = Number(
+        notification.data.conversationId ?? notification.entityId
+      )
+      if (!Number.isSafeInteger(conversationId) || conversationId <= 0) return
+      const senderName =
+        typeof notification.data.senderName === 'string'
+          ? notification.data.senderName
+          : t('notifications.message.senderFallback')
+      const current = groups.get(conversationId)
+      const message: MessageNotification = {
+        id: notification.id,
+        conversationId,
+        senderName,
+        createdAt: notification.createdAt,
+      }
+      if (current) {
+        current.notifications.push(message)
+        current.latestCreatedAt =
+          message.createdAt > current.latestCreatedAt
+            ? message.createdAt
+            : current.latestCreatedAt
+      } else {
+        groups.set(conversationId, {
+          conversationId,
+          senderName,
+          notifications: [message],
+          latestCreatedAt: message.createdAt,
+        })
+      }
+    })
+    return [...groups.values()].sort((a, b) =>
+      b.latestCreatedAt.localeCompare(a.latestCreatedAt)
+    )
+  }, [t, unreadMessageNotifications])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !containerRef.current?.contains(event.target)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
+
+  if (!isAuthenticated || messageGroups.length === 0) return null
+
+  const openConversation = (group: MessageGroup) => {
+    group.notifications.forEach((notification) =>
+      markRead.mutate(notification.id)
+    )
+    setIsOpen(false)
+    navigate('/messages', { state: { conversationId: group.conversationId } })
+  }
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      <button
+        className={styles.trigger}
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls="notification-list"
+        aria-label={t('notifications.open', {
+          count: unreadMessageNotifications.length,
+        })}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <BellIcon aria-hidden="true" />
+        <span className={styles.count} aria-hidden="true">
+          {unreadMessageNotifications.length}
+        </span>
+      </button>
+      {isOpen ? (
+        <div
+          id="notification-list"
+          className={styles.panel}
+          role="dialog"
+          aria-label={t('notifications.title')}
+        >
+          <h2>{t('notifications.title')}</h2>
+          <div className={styles.list}>
+            {messageGroups.map((group) => (
+              <button
+                key={group.conversationId}
+                className={styles.item}
+                type="button"
+                onClick={() => openConversation(group)}
+              >
+                {group.notifications.length === 1
+                  ? t('notifications.message.from', {
+                      name: group.senderName,
+                    })
+                  : t('notifications.message.multipleFrom', {
+                      count: group.notifications.length,
+                      name: group.senderName,
+                    })}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/hooks/api/useNotifications.ts
+++ b/frontend/src/hooks/api/useNotifications.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   fetchNotifications,
   markNotificationRead,
+  type ApiNotification,
   notificationKeys,
 } from '@src/api/notifications/notifications'
 
@@ -17,7 +18,26 @@ export const useNotifications = (options?: { enabled?: boolean }) => {
   })
   const markRead = useMutation({
     mutationFn: markNotificationRead,
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await client.cancelQueries({ queryKey: notificationKeys.all })
+      const previous = client.getQueryData<ApiNotification[]>(
+        notificationKeys.all
+      )
+      client.setQueryData<ApiNotification[]>(notificationKeys.all, (current) =>
+        current?.map((notification) =>
+          notification.id === id
+            ? { ...notification, readAt: new Date().toISOString() }
+            : notification
+        )
+      )
+      return { previous }
+    },
+    onError: (_error, _id, context) => {
+      if (context?.previous) {
+        client.setQueryData(notificationKeys.all, context.previous)
+      }
+    },
+    onSettled: () => {
       void client.invalidateQueries({ queryKey: notificationKeys.all })
     },
   })

--- a/frontend/src/hooks/socket/useChatSocket.ts
+++ b/frontend/src/hooks/socket/useChatSocket.ts
@@ -1,5 +1,6 @@
 import { agreementQueryKeys } from '@api/agreements/agreements'
 import { messageQueryKeys } from '@api/messages/messages'
+import { notificationKeys } from '@api/notifications/notifications'
 import { useQueryClient } from '@tanstack/react-query'
 import { isApiMockMode } from '@utils/runtimeEnv'
 import { useCallback, useEffect, useState } from 'react'
@@ -63,6 +64,7 @@ export const useChatSocket = () => {
       setMessages((prev) => [...prev, msg])
     })
     s.on('conversation:message', (msg: ConversationMessage) => {
+      void queryClient.invalidateQueries({ queryKey: notificationKeys.all })
       void queryClient.invalidateQueries({
         queryKey: messageQueryKeys.history(msg.conversationId),
       })

--- a/frontend/tests/components/notifications/NotificationBell.test.tsx
+++ b/frontend/tests/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ApiNotification } from '@src/api/notifications/notifications'
+import { NotificationBell } from '@src/components/notifications/NotificationBell'
+
+import { renderWithProviders } from '../../test-utils'
+
+const { navigateMock, markReadMock, useAuthMock, useNotificationsMock } =
+  vi.hoisted(() => ({
+    navigateMock: vi.fn(),
+    markReadMock: { mutate: vi.fn() },
+    useAuthMock: vi.fn(),
+    useNotificationsMock: vi.fn(),
+  }))
+
+vi.mock('@src/contexts/auth/AuthContext', async () => {
+  const actual = await vi.importActual<
+    typeof import('@src/contexts/auth/AuthContext')
+  >('@src/contexts/auth/AuthContext')
+  return { ...actual, useAuth: () => useAuthMock() }
+})
+
+vi.mock('@hooks/api/useNotifications', () => ({
+  useNotifications: () => useNotificationsMock(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+const notification = (
+  id: number,
+  conversationId: number,
+  createdAt: string
+): ApiNotification => ({
+  id,
+  kind: 'message',
+  entityId: String(conversationId),
+  titleKey: 'notifications.message.title',
+  bodyKey: 'notifications.message.body',
+  data: { conversationId, senderName: 'Mariano' },
+  readAt: null,
+  createdAt,
+})
+
+describe('NotificationBell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthMock.mockReturnValue({ isAuthenticated: true })
+    useNotificationsMock.mockReturnValue({
+      data: [],
+      markRead: markReadMock,
+    })
+  })
+
+  test('does not render when there are no unread messages', () => {
+    renderWithProviders(<NotificationBell />)
+
+    expect(
+      screen.queryByRole('button', { name: /notifications.open/ })
+    ).toBeNull()
+  })
+
+  test('groups messages and opens the selected conversation', () => {
+    useNotificationsMock.mockReturnValue({
+      data: [
+        notification(1, 10, '2026-08-29T10:00:00.000Z'),
+        notification(2, 10, '2026-08-29T10:01:00.000Z'),
+        notification(3, 11, '2026-08-29T10:02:00.000Z'),
+      ],
+      markRead: markReadMock,
+    })
+
+    renderWithProviders(<NotificationBell />)
+
+    const trigger = screen.getByRole('button', { name: /notifications.open/ })
+    expect(trigger).toHaveTextContent('3')
+    fireEvent.click(trigger)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'notifications.message.multipleFrom',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'notifications.message.from',
+      })
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'notifications.message.multipleFrom',
+      })
+    )
+    expect(markReadMock.mutate).toHaveBeenCalledWith(1)
+    expect(markReadMock.mutate).toHaveBeenCalledWith(2)
+    expect(navigateMock).toHaveBeenCalledWith('/messages', {
+      state: { conversationId: 10 },
+    })
+  })
+})

--- a/openspec/changes/add-in-app-notification-alerts/.openspec.yaml
+++ b/openspec/changes/add-in-app-notification-alerts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/add-in-app-notification-alerts/design.md
+++ b/openspec/changes/add-in-app-notification-alerts/design.md
@@ -1,0 +1,87 @@
+## Context
+
+La aplicación ya tiene notificaciones persistentes para mensajes y acuerdos, una API autenticada para listarlas y marcarlas como leídas, deduplicación por evento y un punto rojo integrado en Mensajes. El frontend consulta ese estado mediante React Query y la mensajería utiliza Socket.IO. La propuesta agrega una forma visible y contextual de consumir esa infraestructura sin crear un centro de notificaciones independiente.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Presentar una campanita flotante solo cuando existan avisos pendientes.
+- Mostrar un contador y una ventana desplazable con avisos agrupados.
+- Agrupar mensajes por conversación y mantener acuerdos como eventos individuales.
+- Abrir la conversación correspondiente y sincronizar el estado leído/no leído.
+- Actualizar la señal mientras la aplicación está abierta.
+- Mantener textos públicos breves y sin datos sensibles.
+
+**Non-Goals:**
+
+- Crear una ruta o página `/notifications`.
+- Diseñar notificaciones por correo o push.
+- Crear recordatorios programados de acuerdos.
+- Navegar hasta un mensaje individual o resaltarlo.
+- Agregar preferencias avanzadas por tipo de evento.
+- Implementar moderación, reputación u otras capacidades del MVP.
+
+## Decisions
+
+### 1. La campanita será un acceso contextual global
+
+La campanita deberá vivir en el layout autenticado que comparten las pantallas. Esto permite que el usuario reciba el aviso desde cualquier sección sin duplicar el componente en cada página.
+
+Alternativa descartada: una nueva página de notificaciones. Se descarta porque contradice el alcance acordado y agrega navegación que no aporta al MVP.
+
+### 2. La ventana mostrará un modelo visual derivado del contrato persistido
+
+La interfaz usará las notificaciones existentes como fuente de verdad. Para la presentación, agrupará los eventos de mensaje por conversación y conservará separados los eventos de acuerdos. El grupo mantendrá la referencia a la conversación para que todas sus notificaciones puedan marcarse como leídas al activarlo.
+
+Alternativa descartada: almacenar grupos nuevos en la base. El agrupamiento es una decisión de presentación y no necesita otro modelo persistente.
+
+### 3. Abrir la ventana no implica leer
+
+La ventana solo permite inspeccionar los avisos. La lectura ocurrirá al activar un aviso o al abrir directamente la conversación, de acuerdo con la semántica ya implementada para mensajes.
+
+Esto evita que el usuario pierda un aviso por abrir accidentalmente la campanita.
+
+### 4. La navegación tendrá como único destino la conversación
+
+Los avisos conservarán el identificador de conversación y abrirán `/messages` con esa conversación seleccionada. No se agrega todavía un contrato de anclaje a mensaje o evento individual.
+
+### 5. La actualización combinará persistencia y tiempo real
+
+La API persistida seguirá siendo la fuente de verdad para el contador, la agrupación y el estado leído. Los eventos Socket.IO podrán invalidar o actualizar la consulta de notificaciones mientras la aplicación está abierta, evitando depender únicamente del intervalo de consulta periódica.
+
+Alternativa descartada: mantener solo polling. El polling conserva tolerancia ante reconexiones, pero por sí solo retrasa la aparición del aviso y no cumple una experiencia inmediata.
+
+### 6. La preferencia general controla la superficie in-app
+
+La preferencia existente de notificaciones in-app se aplicará a la campanita y a los avisos visibles. No se agregan preferencias separadas para mensajes, acuerdos o recordatorios en este cambio.
+
+### 7. La entrega se divide en dos ramas con una pausa explícita
+
+La primera fase se implementará en una rama nueva creada al comenzar el trabajo. Incluirá la superficie de campanita, contador, ventana, agrupamiento de mensajes y navegación a conversaciones. Al terminar, se harán commits en esa rama, se abrirá una PR en español y el agente se detendrá hasta que el usuario la fusione.
+
+La segunda fase se iniciará únicamente después de esa fusión, creando otra rama explícita. Incluirá la integración visual de acuerdos confirmados, la preferencia general visible si corresponde y la actualización final de los estados en tiempo real. También terminará con commits y una PR en español para que el usuario haga el merge.
+
+## Risks / Trade-offs
+
+- **[Avisos desactualizados]** → Mantener la consulta persistida como fuente de verdad, invalidarla después de marcar como leído y conservar polling como recuperación.
+- **[Duplicación visual]** → Usar la clave de evento persistida y agrupar únicamente en la capa de presentación.
+- **[Demasiados avisos]** → Mostrar todos los grupos en una ventana desplazable, sin limitar silenciosamente la cantidad.
+- **[Información privada en el aviso]** → Usar solo nombre público o alias y claves de traducción; nunca correo ni datos de ubicación.
+- **[Interacción fuera de la ventana]** → Cerrar por botón o clic externo sin modificar el estado leído.
+- **[Cambios de contrato]** → Reutilizar `conversationId`/`entityId` existentes y modificar la API solo si una prueba demuestra que falta un dato para navegar.
+
+## Migration Plan
+
+1. Crear la rama de la primera fase a partir de la rama que contenga la OpenSpec.
+2. Implementar y verificar la superficie de avisos de mensajes.
+3. Crear la PR de la primera fase con descripción en español y detenerse para el merge del usuario.
+4. Después del merge, crear una segunda rama desde la rama actualizada.
+5. Implementar la fase de acuerdos, preferencia y cierre de actualización en tiempo real.
+6. Crear la segunda PR en español y detenerse para el merge del usuario.
+
+No se requiere una migración de base de datos prevista para esta OpenSpec. Si durante la implementación apareciera una necesidad real de modificar el contrato persistido, deberá detenerse el trabajo y revisarse el alcance antes de agregar una migración.
+
+## Open Questions
+
+No quedan preguntas de producto bloqueantes. Los detalles de ubicación exacta del componente, estilos, estrategia de invalidación de React Query y composición del evento Socket.IO pertenecen a la implementación y deben mantenerse dentro de los límites de esta especificación.

--- a/openspec/changes/add-in-app-notification-alerts/proposal.md
+++ b/openspec/changes/add-in-app-notification-alerts/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+EntreLibros ya persiste notificaciones y muestra un punto rojo en la sección de Mensajes, pero el usuario no recibe contexto inmediato sobre lo ocurrido ni una forma clara de llegar al chat desde el aviso. Esto deja incompleta la experiencia de HU-5.3 y dificulta comprobar mensajes y acuerdos en el MVP.
+
+## What Changes
+
+- Agregar una campanita flotante visible únicamente cuando existan notificaciones in-app pendientes.
+- Mostrar un contador con la cantidad de avisos pendientes.
+- Abrir una ventana desplegable con los avisos pendientes al hacer clic en la campanita.
+- Agrupar los mensajes pendientes por conversación y mostrar los acuerdos como avisos individuales.
+- Mostrar avisos breves para mensajes nuevos y acuerdos confirmados.
+- Permitir cerrar la ventana sin marcar avisos como leídos.
+- Marcar el aviso como leído y abrir la conversación al hacer clic sobre él.
+- Mantener el punto rojo de Mensajes como señal persistente y marcar como leídas las notificaciones de una conversación al abrirla.
+- Respetar la preferencia general de notificaciones in-app.
+- Mantener la deduplicación existente y evitar avisos para mensajes enviados por el propio usuario.
+- Mantener fuera de este cambio la ruta `/notifications`, las notificaciones por email o push, los recordatorios de acuerdos y la navegación hasta un mensaje exacto.
+
+## Capabilities
+
+### New Capabilities
+
+- `in-app-notifications`: avisos visuales agrupados para mensajes y eventos de acuerdos dentro de la aplicación.
+
+### Modified Capabilities
+
+<!-- No hay especificaciones principales equivalentes en openspec/specs/. -->
+
+## Impact
+
+- Frontend: componente global de campanita y ventana de avisos, agrupación visual, navegación a `/messages` y sincronización del estado leído/no leído.
+- Backend: reutilización y, si fuera necesario, ampliación mínima del contrato existente de notificaciones y sus datos de destino; no se agrega un centro independiente.
+- Tiempo real: integración con los eventos existentes de mensajería para que el aviso pueda aparecer mientras la aplicación está abierta.
+- Preferencias: conexión de la visibilidad de avisos con la preferencia general in-app ya persistida.
+- Pruebas: contratos de API, componentes, estados de agrupación y flujo manual con dos usuarios.
+- Entrega: la implementación se dividirá en dos ramas sucesivas. La primera rama tendrá su propia PR y debe ser mergeada por el usuario antes de crear la segunda. Cada rama tendrá commits propios y una descripción de PR en español.

--- a/openspec/changes/add-in-app-notification-alerts/specs/in-app-notifications/spec.md
+++ b/openspec/changes/add-in-app-notification-alerts/specs/in-app-notifications/spec.md
@@ -1,0 +1,124 @@
+## Purpose
+
+Esta capacidad permite que el usuario conozca eventos relevantes sin abandonar la pantalla actual y pueda acceder rápidamente a la conversación relacionada, manteniendo una experiencia de notificaciones simple dentro del MVP.
+
+## ADDED Requirements
+
+### Requirement: Campanita visible para avisos pendientes
+
+El sistema SHALL mostrar una campanita flotante en la interfaz autenticada únicamente cuando el usuario tenga al menos una notificación in-app no leída. La campanita SHALL mostrar la cantidad de notificaciones pendientes.
+
+#### Scenario: No hay notificaciones pendientes
+
+- **WHEN** el usuario autenticado no tiene notificaciones in-app no leídas
+- **THEN** la campanita flotante no se muestra
+
+#### Scenario: Hay una notificación pendiente
+
+- **WHEN** el usuario autenticado tiene una notificación in-app no leída
+- **THEN** se muestra la campanita flotante con un contador de valor `1`
+
+#### Scenario: Hay varias notificaciones pendientes
+
+- **WHEN** el usuario autenticado tiene dos o más notificaciones in-app no leídas
+- **THEN** se muestra la campanita flotante con el total de avisos pendientes
+
+### Requirement: Ventana de avisos agrupados
+
+El sistema SHALL abrir una ventana desplegable al activar la campanita. La ventana SHALL mostrar todos los avisos pendientes en un área desplazable cuando no entren en el espacio disponible. Las notificaciones de mensajes de una misma conversación SHALL agruparse en un único aviso; las notificaciones de acuerdos SHALL mostrarse como avisos individuales.
+
+#### Scenario: Abrir la ventana de avisos
+
+- **WHEN** el usuario activa la campanita
+- **THEN** se abre una ventana con los avisos pendientes sin cambiar de ruta y sin marcarlos como leídos
+
+#### Scenario: Varios mensajes de una conversación
+
+- **WHEN** existen varias notificaciones pendientes de mensajes para la misma conversación
+- **THEN** la ventana muestra un único aviso agrupado con la cantidad de mensajes y el nombre público de la otra persona
+
+#### Scenario: Avisos de conversaciones diferentes
+
+- **WHEN** existen notificaciones pendientes de conversaciones diferentes
+- **THEN** la ventana muestra un aviso separado para cada conversación
+
+#### Scenario: Mensajes y acuerdos pendientes
+
+- **WHEN** existen notificaciones pendientes de mensajes y de acuerdos
+- **THEN** la ventana muestra los mensajes agrupados por conversación y cada acuerdo como un aviso independiente
+
+#### Scenario: Cerrar la ventana
+
+- **WHEN** el usuario cierra la ventana o activa un área fuera de ella
+- **THEN** la ventana se cierra y las notificaciones conservan su estado no leído
+
+### Requirement: Avisos contextuales del MVP
+
+El sistema SHALL generar avisos visibles para mensajes nuevos recibidos y acuerdos confirmados. El texto SHALL identificar el tipo de evento y utilizar el nombre público o alias disponible, sin mostrar correo electrónico ni datos sensibles.
+
+#### Scenario: Mensaje nuevo recibido
+
+- **WHEN** llega un mensaje nuevo de otra persona
+- **THEN** el usuario recibe un aviso que indica que tiene un mensaje nuevo y quién lo envió
+
+#### Scenario: Acuerdo confirmado
+
+- **WHEN** un acuerdo queda confirmado
+- **THEN** cada participante recibe un aviso que indica que el acuerdo fue confirmado y con quién
+
+#### Scenario: Mensaje propio
+
+- **WHEN** el usuario envía un mensaje
+- **THEN** el sistema no genera para ese mismo usuario un aviso de mensaje recibido
+
+#### Scenario: Preferencia in-app desactivada
+
+- **WHEN** el usuario tiene desactivada la preferencia general de notificaciones in-app
+- **THEN** el sistema no muestra la campanita ni avisos in-app nuevos para ese usuario
+
+### Requirement: Navegación y lectura desde un aviso
+
+Cada aviso SHALL permitir abrir la conversación relacionada. Activar un aviso SHALL marcar como leídas las notificaciones que representa y SHALL navegar a la conversación correspondiente. Abrir una conversación SHALL marcar como leídas las notificaciones de mensajes pendientes de esa conversación.
+
+#### Scenario: Abrir un aviso de mensaje
+
+- **WHEN** el usuario activa un aviso de mensaje
+- **THEN** el sistema marca como leídas las notificaciones representadas y abre la conversación relacionada
+
+#### Scenario: Abrir un aviso de acuerdo
+
+- **WHEN** el usuario activa un aviso de acuerdo confirmado
+- **THEN** el sistema marca como leído ese aviso y abre la conversación donde se registró el acuerdo
+
+#### Scenario: Abrir la conversación directamente
+
+- **WHEN** el usuario entra directamente a una conversación con mensajes pendientes
+- **THEN** las notificaciones de mensajes pendientes de esa conversación quedan marcadas como leídas y la campanita se actualiza
+
+### Requirement: Actualización y deduplicación de avisos
+
+El sistema SHALL actualizar el estado de avisos cuando recibe eventos nuevos mientras la aplicación está abierta y SHALL conservar la deduplicación existente para no presentar dos veces el mismo evento persistido.
+
+#### Scenario: Aviso recibido con la aplicación abierta
+
+- **WHEN** llega un mensaje o se confirma un acuerdo mientras el usuario tiene abierta la aplicación
+- **THEN** la campanita y su contador se actualizan sin recargar manualmente la página
+
+#### Scenario: Evento repetido
+
+- **WHEN** el mismo evento se entrega más de una vez
+- **THEN** se muestra una sola notificación para ese evento
+
+### Requirement: Alcance acotado de la interfaz
+
+El sistema SHALL mantener los avisos integrados en la interfaz existente y no SHALL crear una ruta o sección independiente `/notifications`. Esta capacidad no incluye notificaciones por correo, push, recordatorios temporales ni navegación a un mensaje individual.
+
+#### Scenario: Acceso desde la interfaz principal
+
+- **WHEN** el usuario utiliza la campanita o un aviso
+- **THEN** la interacción ocurre desde la interfaz actual y el destino es una conversación de `/messages`
+
+#### Scenario: Funcionalidad fuera de alcance
+
+- **WHEN** se evalúa el MVP de esta capacidad
+- **THEN** no se exige una bandeja independiente, correo, push, recordatorio programado ni salto a un mensaje exacto

--- a/openspec/changes/add-in-app-notification-alerts/tasks.md
+++ b/openspec/changes/add-in-app-notification-alerts/tasks.md
@@ -1,0 +1,29 @@
+## 1. Primera fase: campanita y avisos de mensajes
+
+- [x] 1.1 Crear explícitamente la rama `feature/in-app-message-notifications` a partir de la rama que contenga esta OpenSpec y verificar con `git branch --show-current` que el trabajo no se realiza sobre `main`.
+- [x] 1.2 Revisar el contrato persistido de notificaciones y confirmar con pruebas que esta primera fase no necesita una migración de base de datos ni una ruta `/notifications`.
+- [x] 1.3 Preparar el modelo visual de notificaciones de mensajes usando el identificador de conversación, el nombre público disponible, el estado leído/no leído y la cantidad de eventos agrupados; verificar tipos de frontend y pruebas del modelo.
+- [x] 1.4 Implementar la campanita flotante autenticada con visibilidad condicional y contador total de avisos pendientes; verificar los estados sin avisos, con un aviso y con varios avisos.
+- [x] 1.5 Implementar la ventana desplegable de avisos de mensajes con agrupación por conversación, scroll para todos los grupos, cierre explícito y cierre por clic externo; verificar teclado, accesibilidad y que abrirla no marque avisos como leídos.
+- [x] 1.6 Implementar el clic de un aviso de mensaje para marcar el grupo correspondiente como leído y abrir la conversación de `/messages`; verificar que el contador, la campanita y el punto rojo se actualicen.
+- [x] 1.7 Integrar la actualización del aviso con los eventos de mensajería y la consulta persistida existente, conservando deduplicación y recuperación por consulta periódica; verificar que un mensaje recibido con la aplicación abierta actualice la señal sin recarga manual.
+- [x] 1.8 Ejecutar las pruebas específicas y generales del frontend, corregir regresiones y realizar la comprobación manual con dos usuarios y dos conversaciones; documentar el resultado en la descripción de la PR.
+- [x] 1.9 Hacer commits claros y concisos en `feature/in-app-message-notifications`, crear una PR con descripción en español en formato GitHub y detener el trabajo hasta que el usuario fusione esa PR.
+
+## 2. Puerta de merge de la primera fase
+
+- [ ] 2.1 Verificar que la primera PR esté publicada, que su rama de destino sea la rama acordada por el usuario y que no se haya realizado ningún merge desde el agente; continuar solo después de la confirmación del usuario de que la PR fue fusionada.
+
+## 3. Segunda fase: acuerdos y preferencia in-app
+
+- [ ] 3.1 Después de la confirmación del merge de la primera fase, crear explícitamente la rama `feature/in-app-agreement-notifications` desde la rama actualizada y verificar que el trabajo no se realiza sobre `main`.
+- [ ] 3.2 Integrar en la ventana existente los avisos individuales de acuerdos confirmados, usando el nombre público o alias y el destino de la conversación; verificar que convivan correctamente con grupos de mensajes.
+- [ ] 3.3 Conectar la preferencia general de notificaciones in-app con la visibilidad de la campanita y los avisos, incorporando un control visible solo si el flujo existente de perfil permite alojarlo sin crear una nueva sección; verificar activación y desactivación.
+- [ ] 3.4 Completar la actualización en tiempo real para mensajes y acuerdos, invalidando o actualizando la consulta persistida sin duplicar eventos; verificar reconexión, entrega repetida y actualización del contador.
+- [ ] 3.5 Verificar que cancelar o cerrar la ventana no marque avisos como leídos y que activar un aviso marque únicamente las notificaciones que representa antes de abrir la conversación.
+
+## 4. Verificación y entrega de la segunda fase
+
+- [ ] 4.1 Ejecutar las pruebas de frontend y backend afectadas, los typechecks, los formateadores y la validación de OpenSpec; corregir todos los errores reales y registrar cualquier warning preexistente.
+- [ ] 4.2 Realizar la comprobación manual con mensajes nuevos, varios mensajes de una conversación, conversaciones distintas, acuerdos confirmados, preferencia desactivada y recarga de la aplicación.
+- [ ] 4.3 Hacer commits claros y concisos en `feature/in-app-agreement-notifications`, crear una PR con descripción en español en formato GitHub y detener el trabajo para que el usuario realice el merge final.


### PR DESCRIPTION
## Resumen

- Agrega una campanita flotante visible solo cuando existen avisos de mensajes sin leer.
- Agrupa varios mensajes de una misma conversación y muestra un contador global.
- Permite abrir la conversación desde cada grupo y marca como leídos únicamente sus avisos.
- Actualiza la consulta de avisos al recibir mensajes por Socket.IO y conserva la recuperación por consulta persistida.
- Incluye el nombre público del remitente en los nuevos avisos, con fallback para avisos históricos.
- Incluye la OpenSpec y sus tareas de la primera fase.

## Alcance

Esta PR implementa únicamente la primera fase: avisos de mensajes. La integración de acuerdos y preferencias generales queda para una segunda rama después del merge manual de esta PR.

## Verificación automatizada

- Test específico de NotificationBell: 2/2.
- Frontend completo: 115 archivos y 376 tests aprobados.
- Backend completo: 112/114; dos timeouts por competencia entre pruebas que usan la misma base durante la ejecución paralela.
- Reproducción aislada de esas dos pruebas con configuración de test y timeout de 15 s: 4/4 aprobadas.
- Typecheck backend/frontend aprobado.
- ESLint backend aprobado; frontend aprobado con un warning preexistente de dependencia innecesaria en Messages.tsx.
- Stylelint aprobado.
- Build backend/frontend aprobado.
- Validación estricta de OpenSpec aprobada.
- git diff --check aprobado.

## Comprobación manual sugerida

1. Iniciar sesión con dos usuarios y crear dos conversaciones distintas.
2. Recibir dos mensajes en una conversación y uno en la otra.
3. Confirmar que aparece la campanita con contador 3 y que el panel muestra dos grupos.
4. Abrir el panel sin seleccionar un aviso y confirmar que el contador no cambia.
5. Seleccionar un grupo y confirmar que navega a /messages, abre esa conversación y descuenta solo sus avisos.
6. Confirmar que al no quedar avisos la campanita desaparece.
7. Recargar la aplicación y confirmar que el estado persistido se conserva.

## Merge

No se realizó ningún merge. Esta PR queda a la espera de revisión y merge manual por parte del usuario. La segunda fase no debe comenzar hasta confirmar que esta PR fue fusionada.