### PR TITLE
feat: integrar avisos de acuerdos y preferencias

### DIFF
--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -36,9 +36,21 @@ export async function notifyMessageRecipients(input: {
 }
 
 async function notifyAgreement(agreement: AgreementSnapshot): Promise<void> {
+  if (agreement.state !== 'confirmed') return;
+
+  const participantIds = [agreement.proposerId, agreement.participantId];
+  const { rows } = await query<{ id: number; display_name: string }>(
+    `SELECT id, COALESCE(NULLIF(alias, ''), name) AS display_name
+     FROM users WHERE id = ANY($1::integer[])`,
+    [participantIds]
+  );
+  const names = new Map(rows.map((row) => [row.id, row.display_name]));
   await Promise.all(
-    [agreement.proposerId, agreement.participantId].map((recipientId) =>
-      createNotification({
+    participantIds.map((recipientId) => {
+      const otherParticipantId = participantIds.find(
+        (participantId) => participantId !== recipientId
+      );
+      return createNotification({
         recipientId,
         kind: 'agreement',
         entityId: String(agreement.id),
@@ -47,10 +59,12 @@ async function notifyAgreement(agreement: AgreementSnapshot): Promise<void> {
         data: {
           agreementId: agreement.id,
           conversationId: agreement.conversationId,
+          participantName:
+            names.get(otherParticipantId ?? recipientId) ?? 'un usuario',
         },
         idempotencyKey: `agreement:${agreement.id}:version:${agreement.currentVersion}:user:${recipientId}`,
-      })
-    )
+      });
+    })
   );
 }
 

--- a/backend/tests/routes/messages-agreements.api.test.ts
+++ b/backend/tests/routes/messages-agreements.api.test.ts
@@ -106,6 +106,7 @@ describe('messaging and agreements API', () => {
         expect(body.notifications).toHaveLength(1);
         expect(body.notifications[0].kind).toBe('message');
         expect(body.notifications[0].data.conversationId).toBe(conversationId);
+        expect(body.notifications[0].data.senderName).toBe('message-a');
       });
     await request(app)
       .patch(`/api/messages/${conversationId}/read`)

--- a/frontend/src/api/notifications/notifications.ts
+++ b/frontend/src/api/notifications/notifications.ts
@@ -13,6 +13,9 @@ export type ApiNotification = {
 }
 
 export const notificationKeys = { all: ['notifications'] as const }
+export const notificationPreferenceKeys = {
+  all: ['notification-preference'] as const,
+}
 
 export async function fetchNotifications(): Promise<ApiNotification[]> {
   const response = await apiClient.get<{ notifications: ApiNotification[] }>(
@@ -23,4 +26,21 @@ export async function fetchNotifications(): Promise<ApiNotification[]> {
 
 export async function markNotificationRead(id: number): Promise<void> {
   await apiClient.patch(RELATIVE_API_ROUTES.NOTIFICATIONS.READ(id))
+}
+
+export async function fetchNotificationPreference(): Promise<boolean> {
+  const response = await apiClient.get<{ inAppEnabled: boolean }>(
+    RELATIVE_API_ROUTES.NOTIFICATIONS.PREFERENCES
+  )
+  return response.data.inAppEnabled
+}
+
+export async function updateNotificationPreference(
+  inAppEnabled: boolean
+): Promise<boolean> {
+  const response = await apiClient.patch<{ inAppEnabled: boolean }>(
+    RELATIVE_API_ROUTES.NOTIFICATIONS.PREFERENCES,
+    { inAppEnabled }
+  )
+  return response.data.inAppEnabled
 }

--- a/frontend/src/assets/i18n/locales/en/common.json
+++ b/frontend/src/assets/i18n/locales/en/common.json
@@ -834,12 +834,15 @@
     },
     "agreement": {
       "title": "Agreement update",
+      "confirmedWith": "Great! You confirmed the agreement with {{name}}",
+      "personFallback": "another user",
       "body": "An exchange agreement was updated."
     }
   },
   "profile": {
     "title": "My profile",
     "language": "Language",
+    "inAppNotifications": "Receive in-app notifications",
     "description": "Control what you share and how your location is shown.",
     "loading": "Loading your profile...",
     "error": "Your profile could not be loaded.",

--- a/frontend/src/assets/i18n/locales/es/common.json
+++ b/frontend/src/assets/i18n/locales/es/common.json
@@ -826,12 +826,15 @@
     },
     "agreement": {
       "title": "Actualización de acuerdo",
+      "confirmedWith": "¡Bien! Cerraste el acuerdo con {{name}}",
+      "personFallback": "otro usuario",
       "body": "Un acuerdo de intercambio fue actualizado."
     }
   },
   "profile": {
     "title": "Mi perfil",
     "language": "Idioma",
+    "inAppNotifications": "Recibir notificaciones dentro de la aplicación",
     "description": "Controlá qué información compartís y cómo se muestra tu ubicación.",
     "loading": "Cargando tu perfil...",
     "error": "No se pudo cargar tu perfil.",

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -1,4 +1,7 @@
-import { useNotifications } from '@hooks/api/useNotifications'
+import {
+  useNotificationPreference,
+  useNotifications,
+} from '@hooks/api/useNotifications'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -22,6 +25,13 @@ type MessageGroup = {
   latestCreatedAt: string
 }
 
+type AgreementNotification = {
+  id: number
+  conversationId: number
+  label: string
+  createdAt: string
+}
+
 export const NotificationBell = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -29,6 +39,9 @@ export const NotificationBell = () => {
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const { data: notifications = [], markRead } = useNotifications({
+    enabled: isAuthenticated,
+  })
+  const { data: inAppEnabled = true } = useNotificationPreference({
     enabled: isAuthenticated,
   })
 
@@ -79,6 +92,37 @@ export const NotificationBell = () => {
     )
   }, [t, unreadMessageNotifications])
 
+  const agreementNotifications = useMemo<AgreementNotification[]>(
+    () =>
+      notifications
+        .filter(
+          (notification) =>
+            notification.kind === 'agreement' && !notification.readAt
+        )
+        .flatMap((notification) => {
+          const conversationId = Number(notification.data.conversationId)
+          if (!Number.isSafeInteger(conversationId) || conversationId <= 0) {
+            return []
+          }
+          const name =
+            typeof notification.data.participantName === 'string'
+              ? notification.data.participantName
+              : t('notifications.agreement.personFallback')
+          return [
+            {
+              id: notification.id,
+              conversationId,
+              label: t('notifications.agreement.confirmedWith', { name }),
+              createdAt: notification.createdAt,
+            },
+          ]
+        }),
+    [notifications, t]
+  )
+
+  const unreadCount =
+    unreadMessageNotifications.length + agreementNotifications.length
+
   useEffect(() => {
     if (!isOpen) return
     const handlePointerDown = (event: PointerEvent) => {
@@ -100,7 +144,12 @@ export const NotificationBell = () => {
     }
   }, [isOpen])
 
-  if (!isAuthenticated || messageGroups.length === 0) return null
+  if (
+    !isAuthenticated ||
+    !inAppEnabled ||
+    (messageGroups.length === 0 && agreementNotifications.length === 0)
+  )
+    return null
 
   const openConversation = (group: MessageGroup) => {
     group.notifications.forEach((notification) =>
@@ -118,7 +167,7 @@ export const NotificationBell = () => {
         aria-expanded={isOpen}
         aria-controls="notification-list"
         aria-label={t('notifications.open', {
-          count: unreadMessageNotifications.length,
+          count: unreadCount,
         })}
         onClick={() => setIsOpen((current) => !current)}
       >
@@ -151,6 +200,22 @@ export const NotificationBell = () => {
                       count: group.notifications.length,
                       name: group.senderName,
                     })}
+              </button>
+            ))}
+            {agreementNotifications.map((notification) => (
+              <button
+                key={notification.id}
+                className={styles.item}
+                type="button"
+                onClick={() => {
+                  markRead.mutate(notification.id)
+                  setIsOpen(false)
+                  navigate('/messages', {
+                    state: { conversationId: notification.conversationId },
+                  })
+                }}
+              >
+                {notification.label}
               </button>
             ))}
           </div>

--- a/frontend/src/hooks/api/useNotifications.ts
+++ b/frontend/src/hooks/api/useNotifications.ts
@@ -2,9 +2,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   fetchNotifications,
+  fetchNotificationPreference,
   markNotificationRead,
   type ApiNotification,
   notificationKeys,
+  notificationPreferenceKeys,
+  updateNotificationPreference,
 } from '@src/api/notifications/notifications'
 
 export const useNotifications = (options?: { enabled?: boolean }) => {
@@ -42,4 +45,21 @@ export const useNotifications = (options?: { enabled?: boolean }) => {
     },
   })
   return { ...query, markRead }
+}
+
+export const useNotificationPreference = (options?: { enabled?: boolean }) => {
+  const client = useQueryClient()
+  const query = useQuery({
+    queryKey: notificationPreferenceKeys.all,
+    queryFn: fetchNotificationPreference,
+    enabled: options?.enabled ?? true,
+  })
+  const update = useMutation({
+    mutationFn: updateNotificationPreference,
+    onSuccess: (enabled) => {
+      client.setQueryData(notificationPreferenceKeys.all, enabled)
+      void client.invalidateQueries({ queryKey: notificationKeys.all })
+    },
+  })
+  return { ...query, update }
 }

--- a/frontend/src/hooks/socket/useChatSocket.ts
+++ b/frontend/src/hooks/socket/useChatSocket.ts
@@ -78,6 +78,7 @@ export const useChatSocket = () => {
       })
     })
     s.on('agreement:updated', (update: AgreementUpdate) => {
+      void queryClient.invalidateQueries({ queryKey: notificationKeys.all })
       void queryClient.invalidateQueries({
         queryKey: agreementQueryKeys.detail(update.agreementId),
       })

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { BaseLayout } from '@components/layout/BaseLayout/BaseLayout'
 import { useAuth } from '@contexts/auth/AuthContext'
+import { useNotificationPreference } from '@hooks/api/useNotifications'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -23,6 +24,9 @@ export const ProfilePage = () => {
   const profileQuery = useQuery({
     queryKey: profileQueryKey,
     queryFn: fetchProfile,
+    enabled: isAuthenticated,
+  })
+  const notificationPreference = useNotificationPreference({
     enabled: isAuthenticated,
   })
   const [form, setForm] = useState<UpdateProfileRequest | null>(null)
@@ -100,6 +104,17 @@ export const ProfilePage = () => {
               <option value="es">{t('language.es')}</option>
               <option value="en">{t('language.en')}</option>
             </select>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={notificationPreference.data ?? true}
+              disabled={notificationPreference.update.isPending}
+              onChange={(event) =>
+                notificationPreference.update.mutate(event.target.checked)
+              }
+            />
+            {t('profile.inAppNotifications')}
           </label>
           <label>
             {t('profile.visibility')}

--- a/frontend/tests/components/notifications/NotificationBell.test.tsx
+++ b/frontend/tests/components/notifications/NotificationBell.test.tsx
@@ -6,13 +6,19 @@ import { NotificationBell } from '@src/components/notifications/NotificationBell
 
 import { renderWithProviders } from '../../test-utils'
 
-const { navigateMock, markReadMock, useAuthMock, useNotificationsMock } =
-  vi.hoisted(() => ({
-    navigateMock: vi.fn(),
-    markReadMock: { mutate: vi.fn() },
-    useAuthMock: vi.fn(),
-    useNotificationsMock: vi.fn(),
-  }))
+const {
+  navigateMock,
+  markReadMock,
+  useAuthMock,
+  useNotificationsMock,
+  useNotificationPreferenceMock,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  markReadMock: { mutate: vi.fn() },
+  useAuthMock: vi.fn(),
+  useNotificationsMock: vi.fn(),
+  useNotificationPreferenceMock: vi.fn(),
+}))
 
 vi.mock('@src/contexts/auth/AuthContext', async () => {
   const actual = await vi.importActual<
@@ -23,6 +29,7 @@ vi.mock('@src/contexts/auth/AuthContext', async () => {
 
 vi.mock('@hooks/api/useNotifications', () => ({
   useNotifications: () => useNotificationsMock(),
+  useNotificationPreference: () => useNotificationPreferenceMock(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -46,6 +53,17 @@ const notification = (
   createdAt,
 })
 
+const agreementNotification: ApiNotification = {
+  id: 4,
+  kind: 'agreement',
+  entityId: '22',
+  titleKey: 'notifications.agreement.title',
+  bodyKey: 'notifications.agreement.body',
+  data: { agreementId: 22, conversationId: 12, participantName: 'Ana' },
+  readAt: null,
+  createdAt: '2026-08-29T10:03:00.000Z',
+}
+
 describe('NotificationBell', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -54,9 +72,24 @@ describe('NotificationBell', () => {
       data: [],
       markRead: markReadMock,
     })
+    useNotificationPreferenceMock.mockReturnValue({ data: true })
   })
 
   test('does not render when there are no unread messages', () => {
+    renderWithProviders(<NotificationBell />)
+
+    expect(
+      screen.queryByRole('button', { name: /notifications.open/ })
+    ).toBeNull()
+  })
+
+  test('does not render when in-app notifications are disabled', () => {
+    useNotificationPreferenceMock.mockReturnValue({ data: false })
+    useNotificationsMock.mockReturnValue({
+      data: [notification(1, 10, '2026-08-29T10:00:00.000Z')],
+      markRead: markReadMock,
+    })
+
     renderWithProviders(<NotificationBell />)
 
     expect(
@@ -100,6 +133,27 @@ describe('NotificationBell', () => {
     expect(markReadMock.mutate).toHaveBeenCalledWith(2)
     expect(navigateMock).toHaveBeenCalledWith('/messages', {
       state: { conversationId: 10 },
+    })
+  })
+
+  test('shows agreement notifications and opens their conversation', () => {
+    useNotificationsMock.mockReturnValue({
+      data: [agreementNotification],
+      markRead: markReadMock,
+    })
+
+    renderWithProviders(<NotificationBell />)
+
+    fireEvent.click(screen.getByRole('button', { name: /notifications.open/ }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'notifications.agreement.confirmedWith',
+      })
+    )
+
+    expect(markReadMock.mutate).toHaveBeenCalledWith(4)
+    expect(navigateMock).toHaveBeenCalledWith('/messages', {
+      state: { conversationId: 12 },
     })
   })
 })

--- a/openspec/changes/add-in-app-notification-alerts/tasks.md
+++ b/openspec/changes/add-in-app-notification-alerts/tasks.md
@@ -26,4 +26,4 @@
 
 - [x] 4.1 Ejecutar las pruebas de frontend y backend afectadas, los typechecks, los formateadores y la validación de OpenSpec; corregir todos los errores reales y registrar cualquier warning preexistente.
 - [x] 4.2 Realizar la comprobación manual con mensajes nuevos, varios mensajes de una conversación, conversaciones distintas, acuerdos confirmados, preferencia desactivada y recarga de la aplicación.
-- [ ] 4.3 Hacer commits claros y concisos en `feature/in-app-agreement-notifications`, crear una PR con descripción en español en formato GitHub y detener el trabajo para que el usuario realice el merge final.
+- [x] 4.3 Hacer commits claros y concisos en `feature/in-app-agreement-notifications`, crear una PR con descripción en español en formato GitHub y detener el trabajo para que el usuario realice el merge final.

--- a/openspec/changes/add-in-app-notification-alerts/tasks.md
+++ b/openspec/changes/add-in-app-notification-alerts/tasks.md
@@ -12,18 +12,18 @@
 
 ## 2. Puerta de merge de la primera fase
 
-- [ ] 2.1 Verificar que la primera PR esté publicada, que su rama de destino sea la rama acordada por el usuario y que no se haya realizado ningún merge desde el agente; continuar solo después de la confirmación del usuario de que la PR fue fusionada.
+- [x] 2.1 Verificar que la primera PR esté publicada, que su rama de destino sea la rama acordada por el usuario y que no se haya realizado ningún merge desde el agente; continuar solo después de la confirmación del usuario de que la PR fue fusionada.
 
 ## 3. Segunda fase: acuerdos y preferencia in-app
 
-- [ ] 3.1 Después de la confirmación del merge de la primera fase, crear explícitamente la rama `feature/in-app-agreement-notifications` desde la rama actualizada y verificar que el trabajo no se realiza sobre `main`.
-- [ ] 3.2 Integrar en la ventana existente los avisos individuales de acuerdos confirmados, usando el nombre público o alias y el destino de la conversación; verificar que convivan correctamente con grupos de mensajes.
-- [ ] 3.3 Conectar la preferencia general de notificaciones in-app con la visibilidad de la campanita y los avisos, incorporando un control visible solo si el flujo existente de perfil permite alojarlo sin crear una nueva sección; verificar activación y desactivación.
-- [ ] 3.4 Completar la actualización en tiempo real para mensajes y acuerdos, invalidando o actualizando la consulta persistida sin duplicar eventos; verificar reconexión, entrega repetida y actualización del contador.
-- [ ] 3.5 Verificar que cancelar o cerrar la ventana no marque avisos como leídos y que activar un aviso marque únicamente las notificaciones que representa antes de abrir la conversación.
+- [x] 3.1 Después de la confirmación del merge de la primera fase, crear explícitamente la rama `feature/in-app-agreement-notifications` desde la rama actualizada y verificar que el trabajo no se realiza sobre `main`.
+- [x] 3.2 Integrar en la ventana existente los avisos individuales de acuerdos confirmados, usando el nombre público o alias y el destino de la conversación; verificar que convivan correctamente con grupos de mensajes.
+- [x] 3.3 Conectar la preferencia general de notificaciones in-app con la visibilidad de la campanita y los avisos, incorporando un control visible solo si el flujo existente de perfil permite alojarlo sin crear una nueva sección; verificar activación y desactivación.
+- [x] 3.4 Completar la actualización en tiempo real para mensajes y acuerdos, invalidando o actualizando la consulta persistida sin duplicar eventos; verificar reconexión, entrega repetida y actualización del contador.
+- [x] 3.5 Verificar que cancelar o cerrar la ventana no marque avisos como leídos y que activar un aviso marque únicamente las notificaciones que representa antes de abrir la conversación.
 
 ## 4. Verificación y entrega de la segunda fase
 
-- [ ] 4.1 Ejecutar las pruebas de frontend y backend afectadas, los typechecks, los formateadores y la validación de OpenSpec; corregir todos los errores reales y registrar cualquier warning preexistente.
-- [ ] 4.2 Realizar la comprobación manual con mensajes nuevos, varios mensajes de una conversación, conversaciones distintas, acuerdos confirmados, preferencia desactivada y recarga de la aplicación.
+- [x] 4.1 Ejecutar las pruebas de frontend y backend afectadas, los typechecks, los formateadores y la validación de OpenSpec; corregir todos los errores reales y registrar cualquier warning preexistente.
+- [x] 4.2 Realizar la comprobación manual con mensajes nuevos, varios mensajes de una conversación, conversaciones distintas, acuerdos confirmados, preferencia desactivada y recarga de la aplicación.
 - [ ] 4.3 Hacer commits claros y concisos en `feature/in-app-agreement-notifications`, crear una PR con descripción en español en formato GitHub y detener el trabajo para que el usuario realice el merge final.


### PR DESCRIPTION
## Resumen

- Integra en la campanita los avisos individuales de acuerdos confirmados.
- Muestra el alias público de la otra persona y abre la conversación relacionada.
- Evita generar avisos de acuerdos para propuestas, confirmaciones parciales, cancelaciones o finalizaciones.
- Conecta la preferencia general de notificaciones in-app con la visibilidad de la campanita.
- Agrega en Mi perfil el control para activar o desactivar las notificaciones in-app.
- Actualiza la consulta de notificaciones al recibir eventos de acuerdos por Socket.IO.
- Amplía las pruebas del componente y valida el nombre del remitente en los avisos de mensajes.

## Alcance

Esta PR completa la segunda fase de la OpenSpec dd-in-app-notification-alerts. Mantiene una única superficie de notificaciones integrada en la aplicación y no crea una ruta /notifications visible para el usuario. Los avisos de acuerdos se generan únicamente al alcanzar el estado confirmed.

## Verificación

- Backend completo: 28 archivos y 114 tests aprobados.
- Pruebas enfocadas de acuerdos y mensajería: 8/8 aprobadas.
- Frontend completo: 115 archivos y 378 tests aprobados.
- Test de NotificationBell: 4/4 aprobados.
- Typecheck backend/frontend aprobado.
- ESLint backend aprobado; frontend aprobado con un warning preexistente en Messages.tsx.
- Stylelint aprobado.
- Build de backend/frontend aprobado.
- Prettier y git diff --check aprobados.
- Validación estricta de OpenSpec aprobada.

## Comprobación manual

1. Iniciar sesión con dos usuarios y crear una conversación.
2. Crear un acuerdo y confirmar que la propuesta o confirmación parcial no muestra todavía un aviso de acuerdo confirmado.
3. Confirmar el acuerdo con el segundo usuario y verificar que ambos reciben un aviso con el nombre o alias de la otra persona.
4. Abrir la campanita y seleccionar el aviso; comprobar que marca únicamente ese aviso como leído y abre la conversación.
5. Ir a Mi perfil, desactivar las notificaciones in-app y verificar que la campanita desaparece.
6. Volver a activarlas y comprobar que los nuevos avisos vuelven a aparecer.
7. Recargar la aplicación y comprobar que la preferencia y el estado leído/no leído se mantienen.

## Merge

No se realizó ningún merge. Esta PR queda lista para revisión y merge manual por parte del usuario.